### PR TITLE
feat: useSelect hook

### DIFF
--- a/libs/future-components/src/client/index.ts
+++ b/libs/future-components/src/client/index.ts
@@ -2,4 +2,5 @@ export { useNotFoundEnhancement } from '../handlers/notFoundEnhancer/useNotFound
 export { usePrompt } from '../handlers/prompt/usePrompt'
 export { useRequest } from '../hooks/useRequest'
 export { useErrorEnhancement } from '../handlers/errorEnhancer/useErrorEnhancement'
+export { useSelect } from '../handlers/select/useSelect'
 export { Block } from '../components/Block'

--- a/libs/future-components/src/components/Select.tsx
+++ b/libs/future-components/src/components/Select.tsx
@@ -1,14 +1,10 @@
 import { useId, type HTMLAttributes, type ReactNode } from 'react'
 import { merge } from '../utils/styles'
-import { request } from '../utils/request'
-import { ApiUrlEnum } from '../enums/ApiUrlEnum'
-import { SelectResponse, SelectRequestBody } from '../handlers/select/models'
-
-export type SelectOptions = Omit<SelectRequestBody, 'prompt'> &
-	Required<Pick<SelectRequestBody, 'prompt'>>
+import { SelectRequestOptions } from '../handlers/select/models'
+import { getSelect } from '../handlers/select/getters'
 
 export interface SelectProps
-	extends SelectOptions,
+	extends SelectRequestOptions,
 		HTMLAttributes<HTMLSelectElement> {
 	/** Visible label in the `<label>` element. Overrides any label from the response */
 	label?: ReactNode
@@ -16,16 +12,6 @@ export interface SelectProps
 	 * Additional props to pass to the <label>
 	 */
 	labelProps?: HTMLAttributes<HTMLLabelElement>
-}
-
-/**
- * Select generation fetcher
- */
-export function getSelect(props: SelectOptions) {
-	const { prompt, context, count } = props || {}
-	const body = { prompt, context, count }
-
-	return request<SelectResponse>(ApiUrlEnum.select, { body })
 }
 
 export async function Select({

--- a/libs/future-components/src/handlers/select/getters.ts
+++ b/libs/future-components/src/handlers/select/getters.ts
@@ -1,0 +1,10 @@
+import { request } from '../../utils/request'
+import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
+import type { SelectResponse, SelectRequestBody } from './models'
+
+/**
+ * Select generation request
+ */
+export function getSelect(body: SelectRequestBody) {
+	return request<SelectResponse>(ApiUrlEnum.select, { body })
+}

--- a/libs/future-components/src/handlers/select/models.ts
+++ b/libs/future-components/src/handlers/select/models.ts
@@ -14,6 +14,9 @@ export class SelectRequestBody {
 	count?: number
 }
 
+export type SelectRequestOptions = Omit<SelectRequestBody, 'prompt'> &
+	Required<Pick<SelectRequestBody, 'prompt'>>
+
 export type SelectResponseItem = {
 	label: string
 	value: string

--- a/libs/future-components/src/handlers/select/useSelect.ts
+++ b/libs/future-components/src/handlers/select/useSelect.ts
@@ -1,0 +1,13 @@
+import type { SelectResponse, SelectRequestBody } from './models'
+import { useRequest, type UseRequestConfig } from '../../hooks/useRequest'
+import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
+
+export const useSelect = (
+	body: SelectRequestBody,
+	config?: UseRequestConfig
+) => {
+	return useRequest<SelectResponse>(ApiUrlEnum.select, {
+		body,
+		...config,
+	})
+}

--- a/libs/future-components/src/index.ts
+++ b/libs/future-components/src/index.ts
@@ -63,6 +63,9 @@ export { Prompt } from './components/Prompt'
 export { Image } from './components/Image'
 export { Select } from './components/Select'
 
+// Service utils
+export { getSelect } from './handlers/select/getters'
+
 // public library api for server
 export { NotFoundEnhancerSitemapSelector } from './handlers/notFoundEnhancer/notFoundEnhancerSitemapSelector'
 export { NotFoundEnhancerContentGenerator } from './handlers/notFoundEnhancer/notFoundEnhancerContentGenerator'

--- a/libs/playground/src/app/(demos)/(prose)/select/UseSelect.tsx
+++ b/libs/playground/src/app/(demos)/(prose)/select/UseSelect.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useSelect } from '@trikinco/fullstack-components/client'
+
+export const UseSelect = () => {
+	const { isLoading, isError, data } = useSelect({
+		prompt:
+			'The 10 nearest countries to Australia. Include a flag emoji in the label.',
+	})
+
+	if (isLoading) {
+		return 'Loading "The 10 nearest countries to Australia"'
+	}
+
+	if (isError) {
+		return 'Could not load "The 10 nearest countries to Australia"'
+	}
+
+	return (
+		<>
+			<p className="font-bold">{data?.label}</p>
+			<ul>
+				{data?.content?.map((item) => <li key={item.value}>{item.label}</li>)}
+			</ul>
+		</>
+	)
+}

--- a/libs/playground/src/app/(demos)/(prose)/select/page.mdx
+++ b/libs/playground/src/app/(demos)/(prose)/select/page.mdx
@@ -1,4 +1,5 @@
 import { Select } from '@trikinco/fullstack-components'
+import { UseSelect } from './UseSelect'
 
 # Select
 
@@ -17,3 +18,46 @@ A smart dropdown component that creates, labels and sorts all its own options.
   context="The time zone for Sydney should be selected"
 />
 ```
+
+## `useSelect`
+
+`useSelect` is a utility hook that allows for full access to Select generation data.
+Useful for generating lists or when creating custom dropdown components.
+
+```jsx
+import { useSelect } from '@trikinco/fullstack-components/client'
+```
+
+```jsx
+'use client'
+
+import { useSelect } from '@trikinco/fullstack-components/client'
+
+export default () => {
+  const { isLoading, isError, data } = useSelect({
+    prompt:
+      'The 10 nearest countries to Australia. Include a flag emoji in the label.',
+  })
+
+  if (isLoading) {
+    return 'Loading "The 10 nearest countries to Australia"'
+  }
+
+  if (isError) {
+    return 'Could not load "The 10 nearest countries to Australia"'
+  }
+
+  return (
+    <>
+      <p className="font-bold">{data?.label}</p>
+      <ul>
+        {data?.content?.map((item) => (
+          <li key={item.value}>{item.label}</li>
+        ))}
+      </ul>
+    </>
+  )
+}
+```
+
+<UseSelect />


### PR DESCRIPTION
- moves select getter to separate file for reusability
- adds `useSelect` example to demo page

![Screenshot 2023-11-20 at 18 57 07](https://github.com/trikinco/fullstack-components/assets/7847281/1173757e-70bf-4103-a3c0-36a7cbec50de)
![Screenshot 2023-11-20 at 18 57 31](https://github.com/trikinco/fullstack-components/assets/7847281/428230f1-e597-4809-bf1b-4594f66664bb)
