### PR TITLE
docs: ensure notFoundEnhancer docs are up to date with API

### DIFF
--- a/libs/future-components/README.md
+++ b/libs/future-components/README.md
@@ -118,19 +118,30 @@ import { useNotFoundEnhancement } from '@trikinco/fullstack-components/client'
 import Link from 'next/link'
 
 export function NotFoundEnhancer() {
-	const { content, isLoading } = useNotFoundEnhancement()
-	if (!content || isLoading) {
+	const { data, isLoading } = useNotFoundEnhancement()
+	const hasUrlSuggestions =
+		data?.bestAlternateUrls && data.bestAlternateUrls.length > 0
+
+	if (!data || isLoading) {
 		return <p>Please wait, checking for other solutions...</p>
 	}
+
 	return (
-		<div>
-			<p>{content?.generatedContent}</p>
-			<p>Try this url instead:</p>
-			<div>
-				<Link href={content?.bestAlternateUrl || '#'}>
-					{content?.bestAlternateUrl || 'No alternate url found'}
-				</Link>
-			</div>
+		<div className="mt-6">
+			<p>{data?.generatedContent}</p>
+			{hasUrlSuggestions && (
+				<>
+					<p className="font-bold">Try one of these pages instead:</p>
+					{data?.bestAlternateUrls.map((url, i) => (
+						<Link href={url} key={i} className="block">
+							{url}
+						</Link>
+					))}
+				</>
+			)}
+			{!hasUrlSuggestions && (
+				<p>Sorry we couldn't find additional pages for you to try this time.</p>
+			)}
 		</div>
 	)
 }

--- a/libs/playground/src/app/docs/errors/page.mdx
+++ b/libs/playground/src/app/docs/errors/page.mdx
@@ -7,7 +7,7 @@ export const metadata = {
     'AI-Powered Error Helper. Makes sense of complex technical errors.',
 }
 
-# Errors
+# Error Enhancer
 
 These error enhancement tools can be used to show users a user-friendly message parsed from an `Error` object, or an in-dept debugging message for developers.
 

--- a/libs/playground/src/app/docs/get-started/page.mdx
+++ b/libs/playground/src/app/docs/get-started/page.mdx
@@ -93,19 +93,35 @@ import { useNotFoundEnhancement } from '@trikinco/fullstack-components/client'
 import Link from 'next/link'
 
 export function NotFoundEnhancer() {
-  const { content, isLoading } = useNotFoundEnhancement()
-  if (!content || isLoading) {
+  const { data, isLoading } = useNotFoundEnhancement()
+  const hasUrlSuggestions =
+    data?.bestAlternateUrls && data.bestAlternateUrls.length > 0
+
+  if (!data || isLoading) {
     return <p>Please wait, checking for other solutions...</p>
   }
+
   return (
-    <div>
-      <p>{content?.generatedContent}</p>
-      <p>Try this url instead:</p>
-      <div>
-        <Link href={content?.bestAlternateUrl || '#'}>
-          {content?.bestAlternateUrl || 'No alternate url found'}
-        </Link>
-      </div>
+    <div className="mt-6">
+      <p>{data?.generatedContent}</p>
+      {hasUrlSuggestions && (
+        <>
+          <p className="font-bold">
+            Try one of these pages instead:
+          </p>
+          {data?.bestAlternateUrls.map((url, i) => (
+            <Link href={url} key={i} className="block">
+              {url}
+            </Link>
+          ))}
+        </>
+      )}
+      {!hasUrlSuggestions && (
+        <p>
+          Sorry we couldn't find additional pages for you to try
+          this time.
+        </p>
+      )}
     </div>
   )
 }

--- a/libs/playground/src/app/docs/not-found/NotFoundEnhancer.tsx
+++ b/libs/playground/src/app/docs/not-found/NotFoundEnhancer.tsx
@@ -2,30 +2,31 @@
 
 import { useNotFoundEnhancement } from '@trikinco/fullstack-components/client'
 import Link from 'next/link'
+import { Spinner } from '@/src/components/Spinner'
 
 export function NotFoundEnhancer() {
-	// load all possible pages (for this segment?)
 	const { data, isLoading } = useNotFoundEnhancement()
+	const hasUrlSuggestions =
+		data?.bestAlternateUrls && data.bestAlternateUrls.length > 0
 
 	if (!data || isLoading) {
-		return <p>Please wait, checking for other solutions...</p>
+		return <Spinner>Please wait, checking for other solutions...</Spinner>
 	}
-	console.log('Enhanced not found data', data)
-	const hasUrls = data?.bestAlternateUrls && data.bestAlternateUrls.length > 0
+
 	return (
 		<div className="mt-6">
 			<p>{data?.generatedContent}</p>
-			{hasUrls && (
+			{hasUrlSuggestions && (
 				<>
-					<p>Try one of these pages instead:</p>
+					<p className="font-bold">Try one of these pages instead:</p>
 					{data?.bestAlternateUrls.map((url, i) => (
-						<div key={i}>
-							<Link href={url}>{url}</Link>
-						</div>
+						<Link href={url} key={i} className="block">
+							{url}
+						</Link>
 					))}
 				</>
 			)}
-			{!hasUrls && (
+			{!hasUrlSuggestions && (
 				<p>
 					Sorry we couldn&amp;t find additional pages for you to try this time.
 				</p>

--- a/libs/playground/src/app/docs/not-found/page.mdx
+++ b/libs/playground/src/app/docs/not-found/page.mdx
@@ -8,10 +8,12 @@ export const metadata = {
 
 # Not Found Enhancer
 
-<NotFoundEnhancer />
-
-This component uses your sitemap to find the closest matching page to the `not found` URL.
+These enhancement tools uses your sitemap to find the closest matching page to the `not found` URL.
 It also uses the contents of your website URL's to create a helpful message for your end-user.
+
+## Example
+
+<NotFoundEnhancer />
 
 ## Setup
 
@@ -43,19 +45,35 @@ import { useNotFoundEnhancement } from '@trikinco/fullstack-components/client'
 import Link from 'next/link'
 
 export function NotFoundEnhancer() {
-  const { content, isLoading } = useNotFoundEnhancement()
-  if (!content || isLoading) {
+  const { data, isLoading } = useNotFoundEnhancement()
+  const hasUrlSuggestions =
+    data?.bestAlternateUrls && data.bestAlternateUrls.length > 0
+
+  if (!data || isLoading) {
     return <p>Please wait, checking for other solutions...</p>
   }
+
   return (
-    <div>
-      <p>{content?.generatedContent}</p>
-      <p>Try this url instead:</p>
-      <div>
-        <Link href={content?.bestAlternateUrl || '#'}>
-          {content?.bestAlternateUrl || 'No alternate url found'}
-        </Link>
-      </div>
+    <div className="mt-6">
+      <p>{data?.generatedContent}</p>
+      {hasUrlSuggestions && (
+        <>
+          <p className="font-bold">
+            Try one of these pages instead:
+          </p>
+          {data?.bestAlternateUrls.map((url, i) => (
+            <Link href={url} key={i} className="block">
+              {url}
+            </Link>
+          ))}
+        </>
+      )}
+      {!hasUrlSuggestions && (
+        <p>
+          Sorry we couldn't find additional pages for you to try
+          this time.
+        </p>
+      )}
     </div>
   )
 }

--- a/libs/playground/src/utils/routes.ts
+++ b/libs/playground/src/utils/routes.ts
@@ -28,12 +28,16 @@ export const routesDocsMeta: RoutesWithMeta[] = [
 		href: routes.prompt,
 	},
 	{
-		title: 'Block',
-		href: routes.block,
+		title: 'Error Enhancer',
+		href: routes.errors,
 	},
 	{
-		title: 'Not found',
+		title: 'Not Found Enhancer',
 		href: routes.notFound,
+	},
+	{
+		title: 'Block',
+		href: routes.block,
 	},
 	{
 		title: 'Image',
@@ -44,20 +48,16 @@ export const routesDocsMeta: RoutesWithMeta[] = [
 		href: routes.select,
 	},
 	{
+		title: 'Text',
+		href: routes.text,
+	},
+	{
 		title: 'Generate UI',
 		href: routes.ui,
 	},
 	{
-		title: 'Error',
-		href: routes.errors,
-	},
-	{
 		title: 'Chat',
 		href: routes.chat,
-	},
-	{
-		title: 'Text',
-		href: routes.text,
 	},
 ]
 


### PR DESCRIPTION
- ensures notFoundEnhancer docs are up to date with API as the example used outdated values
- list docs pages in the side nav in the same order as the index cards
- use same page names/titles as index cards