### PR TITLE
docs: Library name typo and align URL_ naming

### DIFF
--- a/libs/future-components/README.md
+++ b/libs/future-components/README.md
@@ -45,8 +45,8 @@ Create a new [dynamic route](https://nextjs.org/docs/app/building-your-applicati
 
 Depending on which router you use in Next.js, the location of the API handler route will differ:
 
-- Using the Next.js App Router: `app/api/fsutils/[...fscomponents]/route.ts`
-- Using the Next.js Pages Router: `pages/api/fsutils/[...fscomponents].ts`
+- Using the Next.js **App Router**: `app/api/fsutils/[...fscomponents]/route.ts`
+- Using the Next.js **Pages Router**: `pages/api/fsutils/[...fscomponents].ts`
 
 ### Step 2: Configure the API handler route
 
@@ -56,7 +56,7 @@ As an example, let's set up the API handler for the `Image` component by adding 
 import {
 	handleFSComponents,
 	handleImageRequest,
-} from '@trikin-co/fullstack-components'
+} from '@trikinco/fullstack-components'
 
 const fscHandler = handleFSComponents({
 	// Configure one or more handlers
@@ -73,7 +73,7 @@ _All requests to `/api/fsutils/*`(image, prompt, notFoundEnhancer, etc.) will au
 
 **Note:** there's no auth on these endpoints but you can wrap them to add auth.
 
-All handlers can be imported from `@trikin-co/fullstack-components` and are prefixed with `handle`.
+All handlers can be imported from `@trikinco/fullstack-components` and are prefixed with `handle`.
 
 **Handlers examples:**
 

--- a/libs/future-components/src/utils/constants.ts
+++ b/libs/future-components/src/utils/constants.ts
@@ -1,5 +1,7 @@
 export const OPENAI_API_KEY = process.env.OPENAI_API_KEY || 'sk-1234'
-export const URL_HOST = process.env.NEXT_PUBLIC_HOST || 'http://localhost:3000'
+export const PORT = process.env.PORT || 3000
+export const URL_LOCAL = `http://localhost:${PORT}`
+export const URL_HOST = process.env.NEXT_PUBLIC_HOST || URL_LOCAL
 
 // Utils
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/libs/future-components/src/utils/index.ts
+++ b/libs/future-components/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './constants'
+export { ApiUrlEnum } from '../enums/ApiUrlEnum'
 export { request } from './request'
 export { merge } from './styles'
 export { renderToStaticMarkup } from './renderToStaticMarkup'

--- a/libs/playground/src/app/docs/block/page.mdx
+++ b/libs/playground/src/app/docs/block/page.mdx
@@ -1,6 +1,6 @@
 import { Example } from '@/src/components/Example'
 import Blocks from './Blocks'
-import { URL_DEPLOYMENT } from '@/src/utils/constants'
+import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
 
 export const metadata = {
@@ -8,10 +8,7 @@ export const metadata = {
   description:
     'Generate React components with AI. Prompt goes in, component comes out. Easy.',
   alternates: {
-    canonical: `${new URL(
-      routes.block,
-      URL_DEPLOYMENT || URL_BASE
-    )}`,
+    canonical: `${new URL(routes.block, URL_HOST)}`,
   },
 }
 

--- a/libs/playground/src/app/docs/chat-toolkit/page.mdx
+++ b/libs/playground/src/app/docs/chat-toolkit/page.mdx
@@ -1,5 +1,5 @@
 import { Chat } from '@/src/modules/Chat'
-import { URL_DEPLOYMENT } from '@/src/utils/constants'
+import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
 
 export const metadata = {
@@ -7,10 +7,7 @@ export const metadata = {
   description:
     'Everything you need to create fully integrated, custom chat experiences.',
   alternates: {
-    canonical: `${new URL(
-      routes.chat,
-      URL_DEPLOYMENT || URL_BASE
-    )}`,
+    canonical: `${new URL(routes.chat, URL_HOST)}`,
   },
 }
 

--- a/libs/playground/src/app/docs/error-enhancer/page.mdx
+++ b/libs/playground/src/app/docs/error-enhancer/page.mdx
@@ -1,6 +1,6 @@
 import { ErrorHTTPPreview } from './ErrorHTTPPreview'
 import { ClientErrors } from './ClientErrors'
-import { URL_DEPLOYMENT } from '@/src/utils/constants'
+import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
 
 export const metadata = {
@@ -8,10 +8,7 @@ export const metadata = {
   description:
     'AI-Powered Error Helper. Makes sense of complex technical errors.',
   alternates: {
-    canonical: `${new URL(
-      routes.errors,
-      URL_DEPLOYMENT || URL_BASE
-    )}`,
+    canonical: `${new URL(routes.errors, URL_HOST)}`,
   },
 }
 

--- a/libs/playground/src/app/docs/get-started/page.mdx
+++ b/libs/playground/src/app/docs/get-started/page.mdx
@@ -1,5 +1,5 @@
 import {
-  URL_DEPLOYMENT,
+  URL_HOST,
   NAME_SHORT,
   NAME_LONG,
 } from '@/src/utils/constants'
@@ -9,10 +9,7 @@ export const metadata = {
   title: `Get started with ${NAME_SHORT}`,
   description: `Get started with ${NAME_LONG} to build websites by writing prompts`,
   alternates: {
-    canonical: `${new URL(
-      routes.getStarted,
-      URL_DEPLOYMENT || URL_BASE
-    )}`,
+    canonical: `${new URL(routes.getStarted, URL_HOST)}`,
   },
 }
 
@@ -37,8 +34,8 @@ Create a new [dynamic route](https://nextjs.org/docs/app/building-your-applicati
 
 Depending on which router you use in Next.js, the location of the API handler route will differ:
 
-- Using the Next.js App Router: `app/api/fsutils/[...fscomponents]/route.ts`
-- Using the Next.js Pages Router: `pages/api/fsutils/[...fscomponents].ts`
+- Using the Next.js **App Router**: `app/api/fsutils/[...fscomponents]/route.ts`
+- Using the Next.js **Pages Router**: `pages/api/fsutils/[...fscomponents].ts`
 
 ### Step 2: Configure the API handler route
 
@@ -48,7 +45,7 @@ As an example, let's set up the API handler for the `Image` component by adding 
 import {
   handleFSComponents,
   handleImageRequest,
-} from '@trikin-co/fullstack-components'
+} from '@trikinco/fullstack-components'
 
 const fscHandler = handleFSComponents({
   // Configure one or more handlers
@@ -63,7 +60,7 @@ export { fscHandler as GET, fscHandler as POST }
 
 _All requests to `/api/fsutils/*`(image, prompt, notFoundEnhancer, etc.) will automatically be handled by `fullstack-components`, as long as you've added the appropriate handler._
 
-All handlers can be imported from `@trikin-co/fullstack-components` and are prefixed with `handle`.
+All handlers can be imported from `@trikinco/fullstack-components` and are prefixed with `handle`.
 
 **Handlers examples:**
 
@@ -75,6 +72,10 @@ All handlers can be imported from `@trikin-co/fullstack-components` and are pref
 - prompt: handlePromptRequest
 - errorEnhancer: handleErrorRequest
 - notFoundEnhancer: handleNotFoundEnhancement
+
+### Step 3: Add your OpenAI API key
+
+Add `OPENAI_API_KEY=<key>` to an [`.env` file](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables) at the root of your project.
 
 ## Usage example
 

--- a/libs/playground/src/app/docs/get-started/page.mdx
+++ b/libs/playground/src/app/docs/get-started/page.mdx
@@ -95,7 +95,7 @@ This component uses your sitemap to find the closest matching page to the "not f
 
 In the API handler route, you should add the following configuration to use the `useNotFoundEnhancement` hook shown later.
 
-```ts
+```ts title="app/api/fsutils/[...fscomponents]/route.ts"
 export const POST = handleFSComponents({
   notFoundEnhancer: handleNotFoundEnhancement({
     // used to inspect the sitemap

--- a/libs/playground/src/app/docs/get-started/page.mdx
+++ b/libs/playground/src/app/docs/get-started/page.mdx
@@ -23,7 +23,7 @@ npm install @trikinco/fullstack-components
 
 ## Requirements
 
-- `next>=13` - App and Pages Routers are supported!
+- `next>=13` (both App and Pages Routers are supported)
 - Your own [OpenAI API key](https://platform.openai.com/docs/overview)
 
 ## Setup
@@ -73,9 +73,17 @@ All handlers can be imported from `@trikinco/fullstack-components` and are prefi
 - errorEnhancer: handleErrorRequest
 - notFoundEnhancer: handleNotFoundEnhancement
 
-### Step 3: Add your OpenAI API key
+### Step 3: Add Environment Variables
 
-Add `OPENAI_API_KEY=<key>` to an [`.env` file](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables) at the root of your project.
+```sh title=".env.local"
+OPENAI_API_KEY=<key>
+NEXT_PUBLIC_HOST=<url>
+```
+
+- Replace `<key>` with your [OpenAI API key](https://platform.openai.com/docs/overview)
+- Replace `<url>` with the full root URL of your project. e.g `http://localhost:3000` for local development and `https://example.com` for production
+
+Read more about adding [environment variables](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables) to your project.
 
 ## Usage example
 
@@ -85,20 +93,22 @@ This component uses your sitemap to find the closest matching page to the "not f
 
 #### Step 1: Configure the API handler
 
-In the API handler file, you should add the following configuration to use this component.
-
-**Not Found Enhancer requires configuration of the API handler.**
-
-**Note:** not all features require configuration, so read the documentation for each feature.
+In the API handler route, you should add the following configuration to use the `useNotFoundEnhancement` hook shown later.
 
 ```ts
 export const POST = handleFSComponents({
   notFoundEnhancer: handleNotFoundEnhancement({
-    siteUrl: process.env.SITE_URL || '', // used to inspect the sitemap
-    openAiApiKey: process.env.OPENAI_API_KEY || '', // used to generate the contents
+    // used to inspect the sitemap
+    siteUrl: process.env.NEXT_PUBLIC_HOST || '',
+    // used to generate the contents
+    openAiApiKey: process.env.OPENAI_API_KEY || '',
   }),
 })
 ```
+
+**Not Found Enhancer requires configuration of the API handler.**
+
+**Note:** not all features require configuration, so read the documentation for each feature.
 
 #### Step 2: Create a new client component in your Next.js app
 

--- a/libs/playground/src/app/docs/html-page-generator/page.mdx
+++ b/libs/playground/src/app/docs/html-page-generator/page.mdx
@@ -1,5 +1,5 @@
 import { Form } from './Form'
-import { URL_DEPLOYMENT } from '@/src/utils/constants'
+import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
 
 export const metadata = {
@@ -7,10 +7,7 @@ export const metadata = {
   description:
     'AI-Powered HTML page generator that designs and codes user interfaces.',
   alternates: {
-    canonical: `${new URL(
-      routes.htmlPage,
-      URL_DEPLOYMENT || URL_BASE
-    )}`,
+    canonical: `${new URL(routes.htmlPage, URL_HOST)}`,
   },
 }
 

--- a/libs/playground/src/app/docs/image/page.mdx
+++ b/libs/playground/src/app/docs/image/page.mdx
@@ -1,6 +1,6 @@
 import { Image } from '@trikinco/fullstack-components'
 import { Example } from '@/src/components/Example'
-import { URL_DEPLOYMENT } from '@/src/utils/constants'
+import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
 import catImage from '../../../../public/images/A-photograph-of-a-cat-wearing-a-cowboy-hat.png'
 
@@ -9,10 +9,7 @@ export const metadata = {
   description:
     'Create images with prompts or generate image descriptions.',
   alternates: {
-    canonical: `${new URL(
-      routes.image,
-      URL_DEPLOYMENT || URL_BASE
-    )}`,
+    canonical: `${new URL(routes.image, URL_HOST)}`,
   },
 }
 

--- a/libs/playground/src/app/docs/not-found-enhancer/page.mdx
+++ b/libs/playground/src/app/docs/not-found-enhancer/page.mdx
@@ -1,6 +1,6 @@
 import { Example } from '@/src/components/Example'
 import { NotFoundEnhancer } from './NotFoundEnhancer'
-import { URL_DEPLOYMENT } from '@/src/utils/constants'
+import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
 
 export const metadata = {
@@ -8,10 +8,7 @@ export const metadata = {
   description:
     'AI-Powered Page Not Found. Get help finding the page you were looking for.',
   alternates: {
-    canonical: `${new URL(
-      routes.notFound,
-      URL_DEPLOYMENT || URL_BASE
-    )}`,
+    canonical: `${new URL(routes.notFound, URL_HOST)}`,
   },
 }
 

--- a/libs/playground/src/app/docs/prompt/page.mdx
+++ b/libs/playground/src/app/docs/prompt/page.mdx
@@ -1,6 +1,6 @@
 import { Prompt } from '@trikinco/fullstack-components'
 import { Example } from '@/src/components/Example'
-import { URL_DEPLOYMENT } from '@/src/utils/constants'
+import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
 
 export const metadata = {
@@ -8,10 +8,7 @@ export const metadata = {
   description:
     'Easily integrate AI prompts into any part of your application.',
   alternates: {
-    canonical: `${new URL(
-      routes.prompt,
-      URL_DEPLOYMENT || URL_BASE
-    )}`,
+    canonical: `${new URL(routes.prompt, URL_HOST)}`,
   },
 }
 

--- a/libs/playground/src/app/docs/select/page.mdx
+++ b/libs/playground/src/app/docs/select/page.mdx
@@ -1,6 +1,7 @@
+import { Select } from '@trikinco/fullstack-components'
 import { Example } from '@/src/components/Example'
 import UseSelect from './UseSelect'
-import { URL_DEPLOYMENT } from '@/src/utils/constants'
+import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
 
 export const metadata = {
@@ -8,10 +9,7 @@ export const metadata = {
   description:
     'A smart dropdown component that creates, labels and sorts all its own options.',
   alternates: {
-    canonical: `${new URL(
-      routes.select,
-      URL_DEPLOYMENT || URL_BASE
-    )}`,
+    canonical: `${new URL(routes.select, URL_HOST)}`,
   },
 }
 

--- a/libs/playground/src/app/docs/text/page.mdx
+++ b/libs/playground/src/app/docs/text/page.mdx
@@ -1,6 +1,6 @@
 import { Text } from '@trikinco/fullstack-components'
 import { Example } from '@/src/components/Example'
-import { URL_DEPLOYMENT } from '@/src/utils/constants'
+import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
 
 export const metadata = {
@@ -8,10 +8,7 @@ export const metadata = {
   description:
     'Rewrite, simplify or create text. Handles plain text, markdown and HTML',
   alternates: {
-    canonical: `${new URL(
-      routes.text,
-      URL_DEPLOYMENT || URL_BASE
-    )}`,
+    canonical: `${new URL(routes.text, URL_HOST)}`,
   },
 }
 

--- a/libs/playground/src/app/examples/page.mdx
+++ b/libs/playground/src/app/examples/page.mdx
@@ -7,7 +7,7 @@ import Demo from '@/src/components/Demo'
 import {
   NAME_LONG,
   NAME_SHORT,
-  URL_DEPLOYMENT,
+  URL_HOST,
 } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
 
@@ -15,10 +15,7 @@ export const metadata = {
   title: `Live examples of ${NAME_LONG}`,
   description: `Try these interactive examples from ${NAME_SHORT}`,
   alternates: {
-    canonical: `${new URL(
-      routes.examples,
-      URL_DEPLOYMENT || URL_BASE
-    )}`,
+    canonical: `${new URL(routes.examples, URL_HOST)}`,
   },
 }
 

--- a/libs/playground/src/app/layout.tsx
+++ b/libs/playground/src/app/layout.tsx
@@ -6,8 +6,7 @@ import { Footer } from '@/src/components/Footer'
 import { Nav } from '@/src/components/Nav'
 import SkipLink from '@/src/components/SkipLink'
 import {
-	URL_BASE,
-	URL_DEPLOYMENT,
+	URL_HOST,
 	NAME_SHORT,
 	NAME_LONG,
 	META_AUTHORS,
@@ -22,7 +21,7 @@ export const viewport: Viewport = {
 }
 
 export const metadata: Metadata = {
-	metadataBase: new URL(URL_DEPLOYMENT || URL_BASE),
+	metadataBase: new URL(URL_HOST),
 	description: NAME_LONG,
 	keywords: ['Fullstack', 'Components', 'Next.js', 'React', 'AI'],
 	authors: META_AUTHORS,

--- a/libs/playground/src/app/page.tsx
+++ b/libs/playground/src/app/page.tsx
@@ -6,7 +6,7 @@ import {
 	NAME_SHORT,
 	NAME_DESCRIPTION,
 	META_AUTHORS,
-	URL_DEPLOYMENT,
+	URL_HOST,
 	URL_LICENSE,
 	URL_RELEASES,
 	URL_DISCUSSIONS,
@@ -18,7 +18,7 @@ import { JsonSchema } from '@/src/modules/JsonSchema'
 
 export const metadata = {
 	alternates: {
-		canonical: URL_DEPLOYMENT,
+		canonical: URL_HOST,
 	},
 }
 
@@ -29,11 +29,11 @@ const META_AUTHORS_SCHEMA = META_AUTHORS.map((author) => ({
 
 const META_DOCS_SCHEMA = routesDocsMeta.map((meta) => ({
 	'@type': 'WebPage',
-	'@id': `${URL_DEPLOYMENT}${meta.href}`,
+	'@id': `${URL_HOST}${meta.href}`,
 	name: meta.title,
-	url: `${URL_DEPLOYMENT}${meta.href}`,
+	url: `${URL_HOST}${meta.href}`,
 	isPartOf: {
-		'@id': `${URL_DEPLOYMENT}${routes.docs}`,
+		'@id': `${URL_HOST}${routes.docs}`,
 	},
 }))
 
@@ -44,8 +44,8 @@ export default function Home() {
 				type="SoftwareApplication"
 				name={NAME_SHORT}
 				description={NAME_DESCRIPTION}
-				url={URL_DEPLOYMENT}
-				id={URL_DEPLOYMENT}
+				url={URL_HOST}
+				id={URL_HOST}
 				applicationCategory="DeveloperApplication"
 				operatingSystem="Cross-platform"
 				license={URL_LICENSE}
@@ -64,11 +64,11 @@ export default function Home() {
 				hasPart={[
 					{
 						'@type': 'WebPage',
-						'@id': `${URL_DEPLOYMENT}${routes.docs}`,
+						'@id': `${URL_HOST}${routes.docs}`,
 						name: 'Documentation',
-						url: `${URL_DEPLOYMENT}${routes.docs}`,
+						url: `${URL_HOST}${routes.docs}`,
 						isPartOf: {
-							'@id': URL_DEPLOYMENT,
+							'@id': URL_HOST,
 						},
 						hasPart: META_DOCS_SCHEMA,
 					},

--- a/libs/playground/src/app/robots.ts
+++ b/libs/playground/src/app/robots.ts
@@ -1,5 +1,5 @@
 import { MetadataRoute } from 'next'
-import { URL_BASE, URL_DEPLOYMENT } from '../utils/constants'
+import { URL_HOST } from '../utils/constants'
 
 export default function robots(): MetadataRoute.Robots {
 	return {
@@ -7,6 +7,6 @@ export default function robots(): MetadataRoute.Robots {
 			userAgent: '*',
 			allow: '/',
 		},
-		sitemap: `${new URL('sitemap.xml', URL_DEPLOYMENT || URL_BASE)}`,
+		sitemap: `${new URL('sitemap.xml', URL_HOST)}`,
 	}
 }

--- a/libs/playground/src/utils/constants.ts
+++ b/libs/playground/src/utils/constants.ts
@@ -1,4 +1,10 @@
 // Utils
+export const PORT = process.env.PORT || 3000
+export const URL_LOCAL = `http://localhost:${PORT}`
+export const URL_HOST =
+	process.env.VERCEL_ENV === 'preview'
+		? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
+		: process.env.NEXT_PUBLIC_HOST || URL_LOCAL
 export const IS_DEV = process.env.NODE_ENV === 'development'
 
 // Lib-specific
@@ -27,12 +33,3 @@ export const META_AUTHORS = [
 export const ID_DIALOG_PORTAL = 'dialog-portal'
 export const ID_MAIN = 'main-content'
 export const ID_DOCS_NAV = 'docs-nav'
-
-// Use process.env.PORT by default and fallback to port 3000
-export const PORT = process.env.PORT || 3000
-export const URL_BASE = `http://localhost:${PORT}`
-
-export const URL_DEPLOYMENT =
-	process.env.VERCEL_ENV === 'preview'
-		? `https://${process.env.VERCEL_URL}`
-		: process.env.NEXT_PUBLIC_HOST || ''


### PR DESCRIPTION
- @trikin-co -> @trikinco
- Docs and lib both use `URL_HOST` constant naming
- Adds section on environment variables to get-started