### PR TITLE
docs: Extract all type information from the library and display it in "API Reference" sections for each feature

### DIFF
--- a/packages/fullstack-components/src/chatGptService.ts
+++ b/packages/fullstack-components/src/chatGptService.ts
@@ -20,9 +20,19 @@ export type ChatCompletionsOptions = Omit<
 	OpenAI.ChatCompletionCreateParamsNonStreaming,
 	'messages' | 'model'
 > & {
+	/**
+	 * @default `process.env.OPENAI_API_KEY`.
+	 */
 	openAIApiKey: string
-	/** Response format. Sets the `model` and `response_format` appropriately  */
+	/**
+	 * Response format which simplifies enabling JSON mode.
+	 * Sets the `model` and `response_format` appropriately.
+	 */
 	format?: ChatCompletionFormat
+	/**
+	 * ID of the model to use.
+	 * See the [model endpoint compatibility](https://platform.openai.com/docs/models/model-endpoint-compatibility) table for details on which models work with the Chat API.
+	 */
 	model?: OpenAI.ChatCompletionCreateParamsNonStreaming['model']
 }
 

--- a/packages/fullstack-components/src/chatGptService.ts
+++ b/packages/fullstack-components/src/chatGptService.ts
@@ -107,7 +107,7 @@ function selectBestModel(
 	if (format === 'JSON') {
 		/**
 		 * only gpt-4-1106-preview or gpt-3.5-turbo-1106 support JSON mode atm
-		 * @see https://platform.openai.com/docs/guides/text-generation/json-mode
+		 * @link https://platform.openai.com/docs/guides/text-generation/json-mode OpenAI JSON mode
 		 */
 		model = 'gpt-3.5-turbo-1106'
 	}

--- a/packages/fullstack-components/src/client/renderToString.ts
+++ b/packages/fullstack-components/src/client/renderToString.ts
@@ -6,7 +6,7 @@ import { flushSync } from 'react-dom'
 /**
  * Renders a react tree to an HTML string.
  * Uses `createRoot` and `flushSync` as `renderToString` from 'react-dom/server' is disallowed in next
- * @see {@link https://react.dev/reference/react-dom/server/renderToString#removing-rendertostring-from-the-client-code}
+ * @link https://react.dev/reference/react-dom/server/renderToString#removing-rendertostring-from-the-client-code
  * @note client version of `utils/renderToStaticMarkup`
  */
 export async function renderToString(element: ReactNode) {

--- a/packages/fullstack-components/src/components/Block.tsx
+++ b/packages/fullstack-components/src/components/Block.tsx
@@ -9,22 +9,25 @@ import {
 import { useBlock } from '../handlers/block/useBlock'
 
 /**
- * A Block is a React component that is generated and mounted dynamically.
- * @extends `HTMLAttributes<HTMLElement>`
+ * Props to pass to the `<Block>` Client Component.
+ * @extends HTMLAttributes<HTMLElement>
  */
 export interface BlockProps extends HTMLAttributes<HTMLElement> {
-	/** A text description of the desired component. */
+	/**
+	 * A text description of the desired component.
+	 * @example 'A footer with copyright for this year with the company name Acme'
+	 */
 	prompt: string
 	/**
 	 * A React tree to render in the error boundary if the `<Block>` build or renderer fails.
-	 * @see `react-error-boundary` for full type information.
+	 * @link https://www.npmjs.com/package/react-error-boundary `react-error-boundary` for full type information.
 	 */
 	fallback?: ErrorBoundaryPropsWithFallback['fallback']
 	/** A React tree to render in the target root before rendering the `<Block>`. */
 	loading?: ReactNode
 	/**
 	 * Props to pass to the wrapping error boundary.
-	 * @see `react-error-boundary` for full type information.
+	 * @link https://www.npmjs.com/package/react-error-boundary `react-error-boundary` for full type information.
 	 */
 	errorBoundaryProps?: Omit<ErrorBoundaryPropsWithFallback, 'fallback'>
 }
@@ -37,39 +40,40 @@ export type BlockRendererProps = Omit<
 /**
  * BlockRenderer renders any UI React component based on a prompt
  */
-export const BlockRenderer = memo(function BlockRenderer({
-	prompt,
-	loading,
-	...props
-}: BlockRendererProps) {
+export const BlockRenderer = memo(function BlockRenderer(
+	/**
+	 * @link BlockRendererProps
+	 */
+	props: BlockRendererProps
+) {
+	const { prompt, loading, ...rest } = props || {}
 	const { showBoundary } = useErrorBoundary()
 	const { id } = useBlock(prompt, showBoundary)
 
 	return (
-		<div id={id} {...props}>
+		<div id={id} {...rest}>
 			{loading}
 		</div>
 	)
 })
 
 /**
- * Block renders any UI React component based on a prompt
- * This block is wrapped in an ErrorBoundary
+ * Block is a client component that renders a generated React component based on a `prompt`.
+ * @note Each `<Block>` is wrapped in an `ErrorBoundary` to catch any errors thrown during the build or render process.
  */
-export const Block = ({
-	prompt,
-	fallback,
-	errorBoundaryProps,
-	...props
-}: BlockProps) => {
+export function Block(
+	/**
+	 * @link BlockProps
+	 */
+	props: BlockProps
+) {
+	const { prompt, fallback, errorBoundaryProps, ...rest } = props || {}
 	const fallbackTree = fallback || (
 		<>Something went wrong when generating "{prompt}"</>
 	)
 	return (
 		<ErrorBoundary fallback={fallbackTree} {...errorBoundaryProps}>
-			<BlockRenderer prompt={prompt} {...props} />
+			<BlockRenderer prompt={prompt} {...rest} />
 		</ErrorBoundary>
 	)
 }
-
-export default Block

--- a/packages/fullstack-components/src/components/Block.tsx
+++ b/packages/fullstack-components/src/components/Block.tsx
@@ -8,13 +8,24 @@ import {
 } from 'react-error-boundary'
 import { useBlock } from '../handlers/block/useBlock'
 
+/**
+ * A Block is a React component that is generated and mounted dynamically.
+ * @extends `HTMLAttributes<HTMLElement>`
+ */
 export interface BlockProps extends HTMLAttributes<HTMLElement> {
+	/** A text description of the desired component. */
 	prompt: string
-	/** a react tree to render in the error boundary if the Block build or renderer fails */
+	/**
+	 * A React tree to render in the error boundary if the `<Block>` build or renderer fails.
+	 * @see `react-error-boundary` for full type information.
+	 */
 	fallback?: ErrorBoundaryPropsWithFallback['fallback']
-	/** a react tree to render in the root before rendering the Block */
+	/** A React tree to render in the target root before rendering the `<Block>`. */
 	loading?: ReactNode
-	/** props to pass to the wrapping error boundary */
+	/**
+	 * Props to pass to the wrapping error boundary.
+	 * @see `react-error-boundary` for full type information.
+	 */
 	errorBoundaryProps?: Omit<ErrorBoundaryPropsWithFallback, 'fallback'>
 }
 

--- a/packages/fullstack-components/src/components/ErrorEnhancementBoundary.tsx
+++ b/packages/fullstack-components/src/components/ErrorEnhancementBoundary.tsx
@@ -6,14 +6,14 @@ import {
 } from 'react-error-boundary'
 import {
 	ErrorEnhancementFallback,
-	type ErrorEnhancementFallbackBaseProps,
+	type ErrorEnhancementFallbackProps,
 } from './ErrorEnhancementFallback'
 
 export type ErrorBoundaryProps = Omit<
 	ReactErrorBoundaryProps,
 	'FallbackComponent' | 'fallbackRender'
 > &
-	ErrorEnhancementFallbackBaseProps
+	Omit<ErrorEnhancementFallbackProps, 'error' | 'resetErrorBoundary'>
 
 /**
  * A smart error boundary that generates user friendly messages

--- a/packages/fullstack-components/src/components/ErrorEnhancementBoundary.tsx
+++ b/packages/fullstack-components/src/components/ErrorEnhancementBoundary.tsx
@@ -16,12 +16,16 @@ export type ErrorBoundaryProps = Omit<
 	Omit<ErrorEnhancementFallbackProps, 'error' | 'resetErrorBoundary'>
 
 /**
- * A smart error boundary that generates user friendly messages
+ * A smart error boundary Client Component that generates and displays user friendly messages.
+ * Consumes `useErrorEnhancement` and `ErrorEnhancementFallback` under the hood to generate and display the messages.
  */
-export function ErrorEnhancementBoundary({
-	children,
-	...rest
-}: ErrorBoundaryProps) {
+export function ErrorEnhancementBoundary(
+	/**
+	 * @link ErrorEnhancementFallbackProps
+	 */
+	props: ErrorBoundaryProps
+) {
+	const { children, ...rest } = props || {}
 	return (
 		<ReactErrorBoundary
 			fallbackRender={({ error, resetErrorBoundary }) => (
@@ -37,5 +41,3 @@ export function ErrorEnhancementBoundary({
 		</ReactErrorBoundary>
 	)
 }
-
-export default ErrorEnhancementBoundary

--- a/packages/fullstack-components/src/components/ErrorEnhancementFallback.tsx
+++ b/packages/fullstack-components/src/components/ErrorEnhancementFallback.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/naming-convention */
 'use client'
 import type { HTMLAttributes, ReactNode } from 'react'
 import type { FallbackProps } from 'react-error-boundary'
@@ -8,40 +9,44 @@ import { IS_DEV } from '../utils'
 
 /**
  * The fallback component to show in the error boundary when an error is thrown.
- * @extends `HTMLAttributes<HTMLDivElement>`
- * @extends `FallbackProps`
- * @see `react-error-boundary` for `FallbackProps` type information.
+ * @extends HTMLAttributes<HTMLDivElement> & FallbackProps
+ * @link https://www.npmjs.com/package/react-error-boundary `react-error-boundary` for `FallbackProps` type information.
  */
-export type ErrorEnhancementFallbackProps = HTMLAttributes<HTMLDivElement> &
-	FallbackProps & {
-		/** React tree to show while the error enhancement is loading. */
-		fallback?: ReactNode
-		/** Additional context to pass to the error enhancement which may help with debugging. */
-		errorContext?: string
-		/** Shows a button to reset the error boundary and retry the render. */
-		showResetBoundaryButton?: boolean
-		/** Label to display inside the reset `<button>` when `showResetBoundary` is true.  */
-		resetBoundaryButtonLabel?: ReactNode
-		/** Additional props to pass to the reset `<button>`. */
-		resetBoundaryButtonProps?: HTMLAttributes<HTMLButtonElement>
-	}
-
-// export type ErrorEnhancementFallbackProps = ErrorEnhancementFallbackBaseProps &
-// 	FallbackProps
+export interface ErrorEnhancementFallbackProps
+	extends HTMLAttributes<HTMLDivElement>,
+		FallbackProps {
+	/** React tree to show while the error enhancement is loading. */
+	fallback?: ReactNode
+	/** Additional context to pass to the error enhancement which may help with debugging. */
+	errorContext?: string
+	/** Shows a button to reset the error boundary and retry the render. */
+	showResetBoundaryButton?: boolean
+	/** Label to display inside the reset `<button>` when `showResetBoundaryButton` is true.  */
+	resetBoundaryButtonLabel?: ReactNode
+	/** Additional props to pass to the reset `<button>`. */
+	resetBoundaryButtonProps?: HTMLAttributes<HTMLButtonElement>
+}
 
 /**
- * A custom enhanced error fallback component to render inside a `react-error-boundary`
+ * A custom enhanced error fallback Client Component to render inside a `react-error-boundary`.
+ * Consumes `useErrorEnhancement` under the hood to generate the messages, then renders the UI to display them.
  */
-export function ErrorEnhancementFallback({
-	resetErrorBoundary,
-	resetBoundaryButtonLabel = 'Reset',
-	showResetBoundaryButton,
-	resetBoundaryButtonProps,
-	fallback,
-	error,
-	errorContext,
-	...rest
-}: ErrorEnhancementFallbackProps) {
+export function ErrorEnhancementFallback(
+	/**
+	 * @link ErrorEnhancementFallbackProps
+	 */
+	props: ErrorEnhancementFallbackProps
+) {
+	const {
+		resetErrorBoundary,
+		resetBoundaryButtonLabel = 'Reset',
+		showResetBoundaryButton,
+		resetBoundaryButtonProps,
+		fallback,
+		error,
+		errorContext,
+		...rest
+	} = props || {}
 	const { data, isLoading } = useErrorEnhancement({
 		errorContext,
 		errorMessage: error?.message,
@@ -95,5 +100,3 @@ export function ErrorEnhancementFallback({
 		</div>
 	)
 }
-
-export default ErrorEnhancementFallback

--- a/packages/fullstack-components/src/components/ErrorEnhancementFallback.tsx
+++ b/packages/fullstack-components/src/components/ErrorEnhancementFallback.tsx
@@ -6,22 +6,28 @@ import type { FallbackProps } from 'react-error-boundary'
 import { useErrorEnhancement } from '../handlers/errorEnhancer/useErrorEnhancement'
 import { IS_DEV } from '../utils'
 
-export interface ErrorEnhancementFallbackBaseProps
-	extends HTMLAttributes<HTMLDivElement> {
-	/** React tree to show while the error enhancement is loading */
-	fallback?: ReactNode
-	/** Additional context to pass to the error enhancement which may help with debugging */
-	errorContext?: string
-	/** Shows a button to reset the error boundary and retry the render */
-	showResetBoundaryButton?: boolean
-	/** Label to display inside the reset `<button>` when `showResetBoundary` is true  */
-	resetBoundaryButtonLabel?: ReactNode
-	/** Additional props to pass to the reset `<button>` */
-	resetBoundaryButtonProps?: HTMLAttributes<HTMLButtonElement>
-}
+/**
+ * The fallback component to show in the error boundary when an error is thrown.
+ * @extends `HTMLAttributes<HTMLDivElement>`
+ * @extends `FallbackProps`
+ * @see `react-error-boundary` for `FallbackProps` type information.
+ */
+export type ErrorEnhancementFallbackProps = HTMLAttributes<HTMLDivElement> &
+	FallbackProps & {
+		/** React tree to show while the error enhancement is loading. */
+		fallback?: ReactNode
+		/** Additional context to pass to the error enhancement which may help with debugging. */
+		errorContext?: string
+		/** Shows a button to reset the error boundary and retry the render. */
+		showResetBoundaryButton?: boolean
+		/** Label to display inside the reset `<button>` when `showResetBoundary` is true.  */
+		resetBoundaryButtonLabel?: ReactNode
+		/** Additional props to pass to the reset `<button>`. */
+		resetBoundaryButtonProps?: HTMLAttributes<HTMLButtonElement>
+	}
 
-export type ErrorEnhancementFallbackProps = ErrorEnhancementFallbackBaseProps &
-	FallbackProps
+// export type ErrorEnhancementFallbackProps = ErrorEnhancementFallbackBaseProps &
+// 	FallbackProps
 
 /**
  * A custom enhanced error fallback component to render inside a `react-error-boundary`

--- a/packages/fullstack-components/src/components/Image/Image.tsx
+++ b/packages/fullstack-components/src/components/Image/Image.tsx
@@ -27,7 +27,12 @@ function imageEvent<T extends ImageDescribeCallback | ImageGenerateCallback>(
  * - Describes an image by generating `alt` text if you provide an `src` URL and no `alt`.
  * - Otherwise renders as a regular `<Image>` from `next/image`.
  */
-export async function Image(props: ImageProps) {
+export async function Image(
+	/**
+	 * @link ImageProps
+	 */
+	props: ImageProps
+) {
 	const response = await getEnhancedImage(props)
 	const isClient = typeof window !== 'undefined'
 
@@ -67,5 +72,3 @@ export async function Image(props: ImageProps) {
 	// Regular Next image
 	return <NextImage src="" alt="" {...props} />
 }
-
-export default Image

--- a/packages/fullstack-components/src/components/Image/ImageGeneration.tsx
+++ b/packages/fullstack-components/src/components/Image/ImageGeneration.tsx
@@ -6,6 +6,9 @@ import type { ImageGenerateProps } from '../../types/Image'
  * Shows a generated Image
  */
 export function ImageGeneration(
+	/**
+	 * @link ImageGenerateProps
+	 */
 	props: ImageGenerateProps & { response?: string }
 ) {
 	const {
@@ -39,5 +42,3 @@ export function ImageGeneration(
 		</>
 	)
 }
-
-export default ImageGeneration

--- a/packages/fullstack-components/src/components/Prompt.tsx
+++ b/packages/fullstack-components/src/components/Prompt.tsx
@@ -3,13 +3,30 @@ import type { AsComponent } from '../types/AsComponent'
 import type { ChatMessage } from '../types/ChatMessage'
 import { getPrompt } from '../handlers/prompt/promptClient'
 
-export type PromptProps = HTMLAttributes<HTMLElement> & {
-	/** Children to render before the prompt response content */
+export interface PromptOnlyProps {
+	/** A text description of the desired output. */
+	prompt: string
+	/** Children to render before the response content. */
 	children?: ReactNode
-} & (
-		| { prompt: string; messages?: ChatMessage[] }
-		| { prompt?: string; messages: ChatMessage[] }
-	)
+}
+
+export interface PromptWithMessagesProps {
+	/**
+	 * A list of chat completion messages comprising a conversation.
+	 * @see `openai` for full `OpenAI.ChatCompletionMessageParam` type information.
+	 */
+	messages: ChatMessage[]
+	/** Children to render before the response content. */
+	children?: ReactNode
+}
+
+/**
+ * Props to pass to the `<Prompt>`.
+ * @extends `PromptOnlyProps | PromptWithMessagesProps`
+ * @extends `HTMLAttributes<HTMLElement>`.
+ */
+export type PromptProps = HTMLAttributes<HTMLElement> &
+	(PromptOnlyProps | PromptWithMessagesProps)
 
 const defaultElement = 'div'
 

--- a/packages/fullstack-components/src/components/Prompt.tsx
+++ b/packages/fullstack-components/src/components/Prompt.tsx
@@ -3,48 +3,42 @@ import type { AsComponent } from '../types/AsComponent'
 import type { ChatMessage } from '../types/ChatMessage'
 import { getPrompt } from '../handlers/prompt/promptClient'
 
-export interface PromptOnlyProps {
-	/** A text description of the desired output. */
-	prompt: string
-	/** Children to render before the response content. */
-	children?: ReactNode
-}
-
-export interface PromptWithMessagesProps {
+/**
+ * Props to pass to the `<Prompt>` Server Component.
+ * @extends HTMLAttributes<HTMLElement>
+ */
+export interface PromptProps extends HTMLAttributes<HTMLElement> {
+	/**
+	 * A text description of the desired output.
+	 * @example 'The longest river in the world'
+	 */
+	prompt?: string
 	/**
 	 * A list of chat completion messages comprising a conversation.
-	 * @see `openai` for full `OpenAI.ChatCompletionMessageParam` type information.
+	 * @link https://www.npmjs.com/package/openai `openai` for full `OpenAI.ChatCompletionMessageParam` type information.
 	 */
-	messages: ChatMessage[]
-	/** Children to render before the response content. */
+	messages?: ChatMessage[]
+	/**
+	 * Children to render before the response content.
+	 */
 	children?: ReactNode
 }
-
-/**
- * Props to pass to the `<Prompt>`.
- * @extends `PromptOnlyProps | PromptWithMessagesProps`
- * @extends `HTMLAttributes<HTMLElement>`.
- */
-export type PromptProps = HTMLAttributes<HTMLElement> &
-	(PromptOnlyProps | PromptWithMessagesProps)
 
 const defaultElement = 'div'
 
 /**
- * Prompt Server Component
+ * Prompt Server Component.
  * Renders a prompt response as its children.
- *
  * The response can be wrapped in an element by using the `as` prop.
- * @exampe `as` usage
- * `<Prompt prompt="The longest river in the world" as="div" className="text-xl" />` => <div class="text-xl">The longest river in the world is the Nile River</div>
  */
-export async function Prompt<C extends ElementType = typeof defaultElement>({
-	as,
-	prompt,
-	messages,
-	children,
-	...rest
-}: AsComponent<C, PromptProps>) {
+export async function Prompt<C extends ElementType = typeof defaultElement>(
+	/**
+	 * @link PromptProps
+	 * @example `as` usage `<Prompt prompt="The longest river in the world" as="div" className="text-xl" />`
+	 */
+	props: AsComponent<C, PromptProps>
+) {
+	const { as, prompt, messages, children, ...rest } = props || {}
 	const response = await getPrompt({ prompt, messages })
 	const data = response.responseText
 

--- a/packages/fullstack-components/src/components/Select.tsx
+++ b/packages/fullstack-components/src/components/Select.tsx
@@ -1,52 +1,71 @@
 import { useId, type HTMLAttributes, type ReactNode } from 'react'
 import { merge } from '../utils/styles'
 import { getSelect } from '../handlers/select/selectClient'
-import type {
-	SelectRequestOptions,
-	SelectResponse,
-} from '../handlers/select/models'
+import type { SelectResponse } from '../handlers/select/models'
 
-export type {
-	SelectRequestOptions,
-	SelectRequestBody,
-} from '../handlers/select/models'
+export type { SelectRequestBody } from '../handlers/select/models'
 
 /**
- * A smart dropdown component that creates, labels and sorts all its own options.
- * @extends `SelectRequestOptions`
- * @extends `HTMLAttributes<HTMLSelectElement>`.
+ * Props to pass to the `<Select>` Server Component.
+ * @extends HTMLAttributes<HTMLSelectElement>
  */
-export interface SelectProps
-	extends SelectRequestOptions,
-		HTMLAttributes<HTMLSelectElement> {
+export interface SelectProps extends HTMLAttributes<HTMLSelectElement> {
 	/**
-	 * Visible text in the `<label>`. Overrides any `label` from the response.
+	 * A text description for creating the dropdown.
+	 * @example 'All the GMT time zones'
+	 */
+	prompt: string
+	/**
+	 * A text description of the purpose of the dropdown.
+	 * @example 'Selecting your time zone'
+	 */
+	purpose?: string
+	/**
+	 * A text description of additional context or information to help create the dropdown.
+	 * @example 'The time zone for Sydney should be selected'
+	 */
+	context?: string
+	/**
+	 * The number of dropdown options or list items to create.
+	 * @example 10
+	 */
+	count?: number
+	/**
+	 * Visible text in the `<label>` element. Overrides any generated `label` from the response.
 	 */
 	label?: ReactNode
 	/**
-	 * Additional props to pass to the `<label>`.
+	 * Additional props to pass to the `<label>` element.
 	 */
 	labelProps?: HTMLAttributes<HTMLLabelElement>
 }
 
 /**
- * Select Server Component
+ * Select is a smart Server Component for dropdowns that creates, labels and sorts all its own options.
+ * Uses a native `<select>` element.
+ * @extends HTMLAttributes<HTMLSelectElement>
  */
-export async function Select({
-	prompt,
-	context,
-	purpose,
-	count,
-	className,
-	labelProps,
-	label: defaultLabel,
-	...rest
-}: SelectProps) {
+export async function Select(
+	/**
+	 * @link SelectProps
+	 */
+	props: SelectProps
+) {
+	const {
+		prompt,
+		context,
+		purpose,
+		count,
+		className,
+		labelProps,
+		label: defaultLabel,
+		...rest
+	} = props || {}
 	const selectId = useId()
 	const response = await getSelect({ prompt, context, purpose, count })
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 	const { label, content = [] }: SelectResponse = JSON.parse(
-		response.responseText || ''
+		response.responseText || '{}'
 	)
 
 	return (

--- a/packages/fullstack-components/src/components/Select.tsx
+++ b/packages/fullstack-components/src/components/Select.tsx
@@ -6,13 +6,25 @@ import type {
 	SelectResponse,
 } from '../handlers/select/models'
 
+export type {
+	SelectRequestOptions,
+	SelectRequestBody,
+} from '../handlers/select/models'
+
+/**
+ * A smart dropdown component that creates, labels and sorts all its own options.
+ * @extends `SelectRequestOptions`
+ * @extends `HTMLAttributes<HTMLSelectElement>`.
+ */
 export interface SelectProps
 	extends SelectRequestOptions,
 		HTMLAttributes<HTMLSelectElement> {
-	/** Visible label in the `<label>` element. Overrides any label from the response */
+	/**
+	 * Visible text in the `<label>`. Overrides any `label` from the response.
+	 */
 	label?: ReactNode
 	/**
-	 * Additional props to pass to the <label>
+	 * Additional props to pass to the `<label>`.
 	 */
 	labelProps?: HTMLAttributes<HTMLLabelElement>
 }

--- a/packages/fullstack-components/src/components/Text.tsx
+++ b/packages/fullstack-components/src/components/Text.tsx
@@ -1,41 +1,97 @@
 import type { ElementType, HTMLAttributes, ReactNode } from 'react'
 import type { AsComponent } from '../types'
-import type { TextRequestBody, TextResponse } from '../handlers/text/models'
+import type { TextResponse } from '../handlers/text/models'
+import type { Range } from '../types/helpers'
 import { getText } from '../handlers/text/textClient'
 import { renderTreeToString } from '../handlers/text/renderTreeToString'
 
+type HTMLAttributesWithoutContent = Omit<HTMLAttributes<HTMLElement>, 'content'>
+
 /**
- * Text Server Component
- * @extends `Omit<TextRequestBody, 'content'>`
- * @extends `Omit<HTMLAttributes<HTMLElement>, 'content'>`
+ * Props to pass to the `<Text>` Server Component.
+ * @extends Omit<HTMLAttributes<HTMLElement>, 'content'>
+ * @link TextRequestBody
  */
-export interface TextProps
-	extends Omit<TextRequestBody, 'content'>,
-		Omit<HTMLAttributes<HTMLElement>, 'content'> {
-	/** Content to re/write. Plain text or a React tree. */
-	content: ReactNode
+export interface TextProps extends HTMLAttributesWithoutContent {
+	/**
+	 * A text string or a React tree with content to re/write. `children` takes precedence over `content` and accepts the same types.
+	 * @example `<Title>Quantum formalism and the uncertainty principle</Title>`
+	 */
+	content?: ReactNode
+	/**
+	 * A text description of how to re/write the `content`.
+	 * @example 'Summarize the following text in a single, simple sentence.'
+	 */
+	prompt?: string
+	/**
+	 * Enforce a content type for the output.
+	 * Can be used to transform from one type to another. If not defined, the content type should match the input.
+	 * @example 'markdown'
+	 */
+	type?: 'text' | 'markdown' | 'HTML'
+	/**
+	 * A text description defining the tone of voice of the content.
+	 * If not defined, the tone of the input content is matched as closely as possible.
+	 * @example 'friendly and whimsical'
+	 */
+	tone?: string
+	/**
+	 * A number between 0-100 of how heavily the content is modified.
+	 * 0 returns the original content, 100 completely rewrites the content.
+	 * @example 50
+	 */
+	strength?: Range<0, 100>
+	/**
+	 * A number or string that sets the readability level based on school grades.
+	 * Higher numbers creates more complex and harder to read text.
+	 * Lower numbers creates more readable text with simpler words.
+	 * @example 5
+	 * @example '5th-grade'
+	 */
+	grade?: number | string
+	/**
+	 * A number or the *desired* max amount of output text characters, not counting HTML markup if present.
+	 * @note Results vary and may subceed or exceed the desired amount of characters.
+	 * @example 1000
+	 */
+	max?: number
+	/**
+	 * A number of the *desired* minimum amount of output text characters, not counting HTML markup if present.
+	 * @note Results vary and may subceed or exceed the desired amount of characters.
+	 * @example 100
+	 */
+	min?: number
 }
 
 const defaultElement = 'div'
 
 /**
- * Text Server Component
+ * Text Server Component that rewrites its children or `content` prop.
+ * @extends Omit<TextRequestBody, 'content'> Omit<HTMLAttributes<HTMLElement>, 'content'>
+ * @link TextRequestBody
  */
-export async function Text<C extends ElementType = typeof defaultElement>({
-	as,
-	// Text options
-	content,
-	children,
-	prompt,
-	type,
-	tone,
-	strength,
-	grade,
-	max,
-	min,
-	// HTML attributes only
-	...rest
-}: AsComponent<C, TextProps>) {
+export async function Text<C extends ElementType = typeof defaultElement>(
+	/**
+	 * @link TextProps
+	 * @example `as` usage `<Text tone="Ominous" type="HTML" as="div" className="mb-3">Hello friend</Text>`
+	 */
+	props: AsComponent<C, TextProps>
+) {
+	const {
+		as,
+		// Text options
+		content,
+		children,
+		prompt,
+		type,
+		tone,
+		strength,
+		grade,
+		max,
+		min,
+		// HTML attributes only
+		...rest
+	} = props || {}
 	const stringContent = await renderTreeToString(children || content)
 	const response = await getText({
 		content: stringContent,
@@ -48,7 +104,9 @@ export async function Text<C extends ElementType = typeof defaultElement>({
 		min,
 	})
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-	const data: TextResponse = JSON.parse(response.responseText || '')
+	const { content: text = '' }: TextResponse = JSON.parse(
+		response.responseText || '{}'
+	)
 
 	if (as) {
 		const Component = as as 'div' | C
@@ -56,10 +114,10 @@ export async function Text<C extends ElementType = typeof defaultElement>({
 			<Component
 				{...rest}
 				// eslint-disable-next-line @typescript-eslint/naming-convention
-				dangerouslySetInnerHTML={{ __html: data.content }}
+				dangerouslySetInnerHTML={{ __html: text }}
 			/>
 		)
 	}
 
-	return <>{data?.content}</>
+	return <>{text}</>
 }

--- a/packages/fullstack-components/src/components/Text.tsx
+++ b/packages/fullstack-components/src/components/Text.tsx
@@ -1,16 +1,19 @@
-import type { ElementType, ReactNode, HTMLAttributes } from 'react'
+import type { ElementType, HTMLAttributes, ReactNode } from 'react'
 import type { AsComponent } from '../types'
-import type {
-	TextProps as TextOptions,
-	TextResponse,
-} from '../handlers/text/models'
+import type { TextRequestBody, TextResponse } from '../handlers/text/models'
 import { getText } from '../handlers/text/textClient'
 import { renderTreeToString } from '../handlers/text/renderTreeToString'
 
+/**
+ * Text Server Component
+ * @extends `Omit<TextRequestBody, 'content'>`
+ * @extends `Omit<HTMLAttributes<HTMLElement>, 'content'>`
+ */
 export interface TextProps
-	extends Omit<TextOptions, 'content'>,
-		HTMLAttributes<HTMLElement> {
-	children?: ReactNode
+	extends Omit<TextRequestBody, 'content'>,
+		Omit<HTMLAttributes<HTMLElement>, 'content'> {
+	/** Content to re/write. Plain text or a React tree. */
+	content: ReactNode
 }
 
 const defaultElement = 'div'

--- a/packages/fullstack-components/src/handlers/block/blockClient.ts
+++ b/packages/fullstack-components/src/handlers/block/blockClient.ts
@@ -35,8 +35,22 @@ example of EXPECTED output:
 }
 `
 
+/**
+ * Generates code for a React component based on the provided `BlockRequestBody`.
+ *
+ * Block Server Action that calls the third-party API directly on the server. This avoids calling the Next.js API route handler allowing for performant Server Components.
+ * @note The generated code is not bundled or guaranteed to be valid React code.
+ * @link https://nextjs.org/docs/app/building-your-application/data-fetching/patterns Next.js Data Fetching Patterns and Best Practices
+ * @returns {Promise<ChatGptCompletionResponse<string>>} Stringified JSON response
+ */
 export async function getBlock(
+	/**
+	 * @link BlockRequestBody
+	 */
 	request: BlockRequestBody,
+	/**
+	 * @link BlockOptions
+	 */
 	options?: BlockOptions
 ) {
 	'use server'

--- a/packages/fullstack-components/src/handlers/block/fetchers.ts
+++ b/packages/fullstack-components/src/handlers/block/fetchers.ts
@@ -4,10 +4,21 @@ import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 import type { BlockRequestBody, BlockResponse, BlockResult } from './models'
 
 /**
- * Block generation fetcher
+ * Generates code for a React component based on the provided `BlockRequestBody`.
+ *
+ * Block client-side fetch handler that calls the internal Next.js API route handler, then the third-party API. Best used for Client Components and functionality.
+ * @see `ApiUrlEnum.block`
+ * @returns {Promise<BlockResponse>} Stringified JSON response
  */
 export async function fetchBlock(
+	/**
+	 * @link BlockRequestBody
+	 */
 	body: BlockRequestBody,
+	/**
+	 * Fetch utility request options without the `body`
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+	 */
 	config?: RequestConfigOnly
 ) {
 	return request<BlockResponse>(ApiUrlEnum.block, {
@@ -17,11 +28,23 @@ export async function fetchBlock(
 }
 
 /**
- * Block generation and build processing fetcher
- * 'use client'
+ * Generates the code for a React component based on the provided `BlockRequestBody` and processes the response then mounts the component in the DOM element with the specified `id`.
+ * Uses `fetchBlock` under the hood to generate and fetch the block, then uses `esm.sh/build` to process the response and mount the component.
+ *
+ * Block client-side fetch handler that calls the internal Next.js API route handler, then the third-party API. Best used for Client Components and functionality.
+ * @see `ApiUrlEnum.block`
+ * @returns {Promise<BlockResult>} JSON response
  */
 export async function fetchProcessedBlock(
+	/**
+	 * @link BlockRequestBody
+	 * @property {string} id Unique id to assign to a browser DOM element to mount the component in.
+	 */
 	props: BlockRequestBody & { id: string },
+	/**
+	 * Fetch utility request options without the `body`
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+	 */
 	config?: RequestConfigOnly
 ): Promise<BlockResult> {
 	const { id, ...body } = props

--- a/packages/fullstack-components/src/handlers/block/models.ts
+++ b/packages/fullstack-components/src/handlers/block/models.ts
@@ -1,6 +1,7 @@
-export class BlockRequestBody {
+export interface BlockRequestBody {
 	/**
 	 * A text description of the desired component.
+	 * @example 'A footer with copyright for this year with the company name Acme'
 	 */
 	prompt?: string
 }

--- a/packages/fullstack-components/src/handlers/block/models.ts
+++ b/packages/fullstack-components/src/handlers/block/models.ts
@@ -1,4 +1,7 @@
 export class BlockRequestBody {
+	/**
+	 * A text description of the desired component.
+	 */
 	prompt?: string
 }
 
@@ -34,6 +37,9 @@ export type BlockResult = {
 }
 
 export type BlockOptions = {
+	/**
+	 * @default `process.env.OPENAI_API_KEY`.
+	 */
 	openAiApiKey?: string
 }
 

--- a/packages/fullstack-components/src/handlers/block/useBlock.ts
+++ b/packages/fullstack-components/src/handlers/block/useBlock.ts
@@ -15,8 +15,14 @@ export function useBlock(
 	prompt: string,
 	/**
 	 * Callback when errors are thrown. Used to e.g show an error boundary.
+	 * @example `(error) => showBoundary(error)`
 	 */
-	onError?: (error: any) => void
+	onError?: (
+		/**
+		 * The error object thrown by the Block.
+		 */
+		error: any
+	) => void
 ) {
 	const id = useId()
 	// Just for avoiding multiple API calls in strict mode - this isn't really needed

--- a/packages/fullstack-components/src/handlers/block/useBlock.ts
+++ b/packages/fullstack-components/src/handlers/block/useBlock.ts
@@ -4,22 +4,20 @@ import { useId, useRef, useEffect } from 'react'
 import { fetchProcessedBlock } from './fetchers'
 
 /**
- * useBlock generates a React component based on a prompt
- * It uses `createRoot` to render it to an element with the returned `id`
+ * Generates a React component based on a `prompt`.
+ * Uses `createRoot` to mount the component to a browser DOM element assigned with the `id`.
  */
-export interface UseBlockParameters {
+export function useBlock(
 	/**
 	 * A text description of the desired component.
+	 * @example 'A footer with copyright for this year with the company name Acme'
 	 */
-	prompt: string
-	/** Callback when errors are thrown. Used to e.g show an error boundary. */
+	prompt: string,
+	/**
+	 * Callback when errors are thrown. Used to e.g show an error boundary.
+	 */
 	onError?: (error: any) => void
-}
-
-export const useBlock = (
-	prompt: UseBlockParameters['prompt'],
-	onError?: UseBlockParameters['onError']
-) => {
+) {
 	const id = useId()
 	// Just for avoiding multiple API calls in strict mode - this isn't really needed
 	const isEnabled = useRef(true)

--- a/packages/fullstack-components/src/handlers/block/useBlock.ts
+++ b/packages/fullstack-components/src/handlers/block/useBlock.ts
@@ -7,10 +7,18 @@ import { fetchProcessedBlock } from './fetchers'
  * useBlock generates a React component based on a prompt
  * It uses `createRoot` to render it to an element with the returned `id`
  */
-export const useBlock = (
-	prompt: string,
-	/** Callback when errors are thrown. e.g show an error boundary */
+export interface UseBlockParameters {
+	/**
+	 * A text description of the desired component.
+	 */
+	prompt: string
+	/** Callback when errors are thrown. Used to e.g show an error boundary. */
 	onError?: (error: any) => void
+}
+
+export const useBlock = (
+	prompt: UseBlockParameters['prompt'],
+	onError?: UseBlockParameters['onError']
 ) => {
 	const id = useId()
 	// Just for avoiding multiple API calls in strict mode - this isn't really needed

--- a/packages/fullstack-components/src/handlers/errorEnhancer/errorClient.ts
+++ b/packages/fullstack-components/src/handlers/errorEnhancer/errorClient.ts
@@ -3,8 +3,21 @@ import { OPENAI_API_KEY } from '../../utils/constants'
 import type { ChatMessage } from '../../types/ChatMessage'
 import type { ErrorEnhancementRequestBody, ErrorParserOptions } from './models'
 
+/**
+ * Enhances the provided error with additional information.
+ *
+ * Error enhancement Server Action that calls the third-party API directly on the server. This avoids calling the Next.js API route handler allowing for performant Server Components.
+ * @link https://nextjs.org/docs/app/building-your-application/data-fetching/patterns Next.js Data Fetching Patterns and Best Practices
+ * @returns {Promise<ChatGptCompletionResponse<string>>} response
+ */
 export async function getErrorEnhancement(
+	/**
+	 * @link ErrorEnhancementRequestBody
+	 */
 	request: ErrorEnhancementRequestBody,
+	/**
+	 * @link ErrorParserOptions
+	 */
 	options?: ErrorParserOptions
 ) {
 	'use server'

--- a/packages/fullstack-components/src/handlers/errorEnhancer/fetchers.ts
+++ b/packages/fullstack-components/src/handlers/errorEnhancer/fetchers.ts
@@ -7,10 +7,21 @@ import type {
 } from './models'
 
 /**
- * Error enhancement fetcher
+ * Enhances the provided error with additional information.
+ *
+ * Error enhancement client-side fetch handler that calls the internal Next.js API route handler, then the third-party API. Best used for Client Components and functionality.
+ * @see `ApiUrlEnum.errorEnhancer`
+ * @returns {Promise<ErrorEnhancementResponse>} JSON response
  */
 export function fetchErrorEnhancement(
+	/**
+	 * @link ErrorEnhancementRequestBody
+	 */
 	body: ErrorEnhancementRequestBody,
+	/**
+	 * Fetch utility request options without the `body`
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+	 */
 	config?: RequestConfigOnly
 ) {
 	return request<ErrorEnhancementResponse>(ApiUrlEnum.errorEnhancer, {

--- a/packages/fullstack-components/src/handlers/errorEnhancer/models.ts
+++ b/packages/fullstack-components/src/handlers/errorEnhancer/models.ts
@@ -1,23 +1,45 @@
 export type ErrorParserOptions = {
+	/**
+	 * The context of the running app to analyze errors for.
+	 * Helps provide the most relevant type of information.
+	 */
 	appContext?: 'http web app' | 'mobile app' | 'desktop app'
+	/**
+	 * @default `process.env.OPENAI_API_KEY`.
+	 */
 	openAiApiKey?: string
-	/** Overrides the output of `developmentModeContext` messages that are typically only shown when `process.env.NODE_ENV === 'development'` */
+	/**
+	 * Overrides the output of `developmentModeContext` messages that are typically only shown when `process.env.NODE_ENV === 'development'`
+	 */
 	isProd?: boolean
 }
-export class ErrorEnhancementRequestBody {
-	/** The error message to analyze. This will usually be `error.message` */
+
+export interface ErrorEnhancementRequestBody {
+	/** The error message to analyze. This will usually be `error.message` from an `Error` object. */
 	errorMessage?: string
-	/** Additional context and information which may help with debugging */
+	/** Additional context and information which may help with debugging. */
 	errorContext?: string
-	/** The error stack trace to analyze. This will usually be `error.stack` */
+	/** The error stack trace to analyze. This will usually be `error.stack` from an `Error` object. */
 	stackTrace?: string
 }
 
 export type ErrorEnhancementResponse = {
+	/**
+	 * A helpful text message explaining the error to a non-technical user.
+	 */
 	message?: string
+	/**
+	 * A text title related to the `message` explanation.
+	 */
 	title?: string
+	/**
+	 * A helpful text message explaining the potential cause of the error and a possible solution.
+	 * The message is intended for developers.
+	 * Only shown if `process.env.NODE_ENV === 'development'` and `isProd === false`
+	 */
 	developmentModeContext?: string
 }
+
 export class ErrorEnhancementError extends Error {
 	public rootCause: string
 

--- a/packages/fullstack-components/src/handlers/errorEnhancer/useErrorEnhancement.ts
+++ b/packages/fullstack-components/src/handlers/errorEnhancer/useErrorEnhancement.ts
@@ -10,9 +10,14 @@ import type {
 } from './models'
 import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 
-export const useErrorEnhancement = (
-	body: ErrorEnhancementRequestBody,
+export interface UseErrorEnhancementParameters {
+	body: ErrorEnhancementRequestBody
 	config?: UseRequestConsumerConfig<ErrorEnhancementRequestBody>
+}
+
+export const useErrorEnhancement = (
+	body: UseErrorEnhancementParameters['body'],
+	config?: UseErrorEnhancementParameters['config']
 ) => {
 	return useRequest<ErrorEnhancementResponse>(ApiUrlEnum.errorEnhancer, {
 		body,

--- a/packages/fullstack-components/src/handlers/errorEnhancer/useErrorEnhancement.ts
+++ b/packages/fullstack-components/src/handlers/errorEnhancer/useErrorEnhancement.ts
@@ -10,15 +10,21 @@ import type {
 } from './models'
 import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 
-export interface UseErrorEnhancementParameters {
-	body: ErrorEnhancementRequestBody
+/**
+ * A client-side fetch handler hook for enhancing the provided error with additional information to help users and developers.
+ * @see `ApiUrlEnum.errorEnhancer`
+ */
+export function useErrorEnhancement(
+	/**
+	 * @link ErrorEnhancementRequestBody
+	 */
+	body: ErrorEnhancementRequestBody,
+	/**
+	 * Fetch utility hook request options without the `fetcher`. Allows for overriding the default `request` config.
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+	 */
 	config?: UseRequestConsumerConfig<ErrorEnhancementRequestBody>
-}
-
-export const useErrorEnhancement = (
-	body: UseErrorEnhancementParameters['body'],
-	config?: UseErrorEnhancementParameters['config']
-) => {
+) {
 	return useRequest<ErrorEnhancementResponse>(ApiUrlEnum.errorEnhancer, {
 		body,
 		...config,

--- a/packages/fullstack-components/src/handlers/htmlPage/fetchers.ts
+++ b/packages/fullstack-components/src/handlers/htmlPage/fetchers.ts
@@ -4,10 +4,21 @@ import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 import type { HtmlPageResponse, HtmlPageRequestBody } from './models'
 
 /**
- * Html page generation fetcher
+ * Generates a website based on the provided `HtmlPageRequestBody`.
+ *
+ * HtmlPage generation client-side fetch handler that calls the internal Next.js API route handler, then the third-party API. Best used for Client Components and functionality.
+ * @see `ApiUrlEnum.htmlPage`
+ * @returns {Promise<HtmlPageResponse>} JSON response
  */
 export async function fetchHtmlPage(
+	/**
+	 * @link HtmlPageRequestBody
+	 */
 	body: HtmlPageRequestBody,
+	/**
+	 * Fetch utility request options without the `body`
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+	 */
 	config?: RequestConfigOnly
 ) {
 	return request<HtmlPageResponse>(ApiUrlEnum.htmlPage, {

--- a/packages/fullstack-components/src/handlers/htmlPage/htmlPageClient.ts
+++ b/packages/fullstack-components/src/handlers/htmlPage/htmlPageClient.ts
@@ -35,8 +35,22 @@ You use any provided list of TailwindCSS colors in the UI you create. EXAMPLE li
 You use images from Unsplash, placehold.co (or similar) or colored rectangles
 `
 
+/**
+ * Generates a website based on the provided `HtmlPageRequestBody`.
+ *
+ * HtmlPage Server Action that calls the third-party API directly on the server. This avoids calling the Next.js API route handler allowing for performant Server Components.
+ * @note uses the `gpt-4-vision-preview` model and returns a maximum of 4096 output tokens
+ * @link https://nextjs.org/docs/app/building-your-application/data-fetching/patterns Next.js Data Fetching Patterns and Best Practices
+ * @returns {Promise<ChatGptCompletionResponse<string>>} Stringified JSON response
+ */
 export async function getHtmlPage(
+	/**
+	 * @link HtmlPageRequestBody
+	 */
 	request: HtmlPageRequestBody,
+	/**
+	 * @link HtmlPageOptions
+	 */
 	options?: HtmlPageOptions
 ) {
 	'use server'

--- a/packages/fullstack-components/src/handlers/htmlPage/models.ts
+++ b/packages/fullstack-components/src/handlers/htmlPage/models.ts
@@ -1,19 +1,25 @@
-export class HtmlPageRequestBody {
-	/** Description of the HTML page you want to build or modify */
+export interface HtmlPageRequestBody {
+	/** Description of the HTML page you want to build or modify. */
 	prompt?: string
-	/** An absolute URL to a reference image to base the HTML page on */
+	/** An absolute URL to a reference image to base the HTML page on. */
 	src?: string
-	/** A list of unprefixed TailwindCSS colors to use, e.g 'blue-400' */
+	/**
+	 * A comma-separated list of unprefixed TailwindCSS colors to use.
+	 * @example 'blue-400,red-600'
+	 */
 	colors?: string
-	/** Whether to make the UI light or dark theme, equivalent to media prefers-color-scheme */
+	/** The theme to make the UI for, equivalent to media `prefers-color-scheme`. */
 	theme?: 'light' | 'dark'
-	/** A HTML page to modify or iterate on */
+	/** A HTML page to modify or iterate on. */
 	html?: string
 }
 
 export type HtmlPageResponse = string
 
 export type HtmlPageOptions = {
+	/**
+	 * @default `process.env.OPENAI_API_KEY`.
+	 */
 	openAiApiKey?: string
 }
 

--- a/packages/fullstack-components/src/handlers/htmlPage/models.ts
+++ b/packages/fullstack-components/src/handlers/htmlPage/models.ts
@@ -1,16 +1,28 @@
 export interface HtmlPageRequestBody {
-	/** Description of the HTML page you want to build or modify. */
+	/**
+	 * A text description of the HTML page you want to build or modify.
+	 * @example 'A colorful about page for a cat named "Fluffy". Rounded corners, a gradient background, and a centered image of a cat.'
+	 */
 	prompt?: string
-	/** An absolute URL to a reference image to base the HTML page on. */
+	/**
+	 * An absolute URL to a reference image to base the design of the entire HTML page on.
+	 * @example 'https://absolute-cat-inspiration/tabbycat-ui.jpg'
+	 */
 	src?: string
 	/**
-	 * A comma-separated list of unprefixed TailwindCSS colors to use.
+	 * A comma-separated list of unprefixed TailwindCSS colors to use in the generated HTML page.
 	 * @example 'blue-400,red-600'
 	 */
 	colors?: string
-	/** The theme to make the UI for, equivalent to media `prefers-color-scheme`. */
+	/**
+	 * The theme to make the UI for, equivalent to media `prefers-color-scheme`.
+	 * @example 'dark'
+	 */
 	theme?: 'light' | 'dark'
-	/** A HTML page to modify or iterate on. */
+	/**
+	 * A stringified HTML page to modify or iterate on. Useful when allowing for follow-up calls to modify a previously generated HTML page.
+	 * @example '<html><body><h1>Henlo, world!</h1></body></html>'
+	 */
 	html?: string
 }
 

--- a/packages/fullstack-components/src/handlers/htmlPage/useHtmlPage.ts
+++ b/packages/fullstack-components/src/handlers/htmlPage/useHtmlPage.ts
@@ -8,12 +8,18 @@ import {
 import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 
 /**
- * Creates a HTML page based on prompts
- * Will by default set the `theme` to the current `prefers-color-scheme` setting
+ * HTML Page client hook.
+ * Creates a HTML page based on prompts.
+ * Will by default set the `theme` to the current `prefers-color-scheme` setting.
  */
-export const useHtmlPage = (
-	body: HtmlPageRequestBody,
+export interface UseHtmlPageParameters {
+	body: HtmlPageRequestBody
 	config?: UseRequestConsumerConfig<HtmlPageRequestBody>
+}
+
+export const useHtmlPage = (
+	body: UseHtmlPageParameters['body'],
+	config?: UseHtmlPageParameters['config']
 ) => {
 	const isPrefersDark =
 		typeof window !== 'undefined' &&

--- a/packages/fullstack-components/src/handlers/htmlPage/useHtmlPage.ts
+++ b/packages/fullstack-components/src/handlers/htmlPage/useHtmlPage.ts
@@ -8,19 +8,22 @@ import {
 import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 
 /**
- * HTML Page client hook.
- * Creates a HTML page based on prompts.
- * Will by default set the `theme` to the current `prefers-color-scheme` setting.
+ * A client-side fetch handler hook for creating a HTML page based on a provided `prompt`, and other optional parameters.
+ * @default `theme` is set to the current `prefers-color-scheme` value using `window.matchMedia`
+ * @see `ApiUrlEnum.htmlPage`
  */
-export interface UseHtmlPageParameters {
-	body: HtmlPageRequestBody
+export function useHtmlPage(
+	/**
+	 * @link HtmlPageRequestBody
+	 * @default `theme` is set to the current `prefers-color-scheme` value using `window.matchMedia`
+	 */
+	body: HtmlPageRequestBody,
+	/**
+	 * Fetch utility hook request options without the `fetcher`. Allows for overriding the default `request` config.
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+	 */
 	config?: UseRequestConsumerConfig<HtmlPageRequestBody>
-}
-
-export const useHtmlPage = (
-	body: UseHtmlPageParameters['body'],
-	config?: UseHtmlPageParameters['config']
-) => {
+) {
 	const isPrefersDark =
 		typeof window !== 'undefined' &&
 		window.matchMedia('(prefers-color-scheme: dark)').matches

--- a/packages/fullstack-components/src/handlers/image/fetchers.ts
+++ b/packages/fullstack-components/src/handlers/image/fetchers.ts
@@ -5,10 +5,20 @@ import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 import type { ImageRequestBody } from './models'
 
 /**
- * Image generation and description fetcher
+ * Generates one or more images or describes a single image based on the provided `ImageRequestBody`. When generating an image returns a single image URL or an array of image URLs if `n` is > 1.
+ *
+ * Image generation and description client-side fetch handler that calls the internal Next.js API route handler, then the third-party API. Best used for Client Components and functionality.
+ * @see `ApiUrlEnum.image`
  */
 export function fetchImage(
+	/**
+	 * @link ImageRequestBody
+	 */
 	body: ImageRequestBody & { n?: 1 | 0 | null },
+	/**
+	 * Fetch utility request options without the `body`
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+	 */
 	config?: RequestConfigOnly
 ): ReturnType<typeof request<string, ImageRequestBody>>
 export function fetchImage(

--- a/packages/fullstack-components/src/handlers/image/getters.ts
+++ b/packages/fullstack-components/src/handlers/image/getters.ts
@@ -9,10 +9,20 @@ import type {
 import { getImage } from './imageClient'
 
 /**
- * Image generation and description getter
- * Used to make enhanced `Image` components similar to `next/image`
+ * Generates or describes a single image based on the provided `ImageProps`.
+ * Logs warnings in development if `alt` is provided without `prompt`.
+ * Used specifically for wrapping the `Image` component from `next/image`.
+ *
+ * Image Server Action that calls the third-party API directly on the server. This avoids calling the Next.js API route handler allowing for performant Server Components.
+ * @link https://nextjs.org/docs/app/building-your-application/data-fetching/patterns Next.js Data Fetching Patterns and Best Practices
+ * @returns {Promise<string>} Text description or the base64 string or URL of the generated image
  */
-export async function getEnhancedImage(props: ImageProps) {
+export async function getEnhancedImage(
+	/**
+	 * @link ImageProps
+	 */
+	props: ImageProps
+) {
 	const {
 		prompt,
 		src,

--- a/packages/fullstack-components/src/handlers/image/imageClient.ts
+++ b/packages/fullstack-components/src/handlers/image/imageClient.ts
@@ -18,8 +18,22 @@ There's usually no need to include words like "image", "icon", or "picture" in t
 Perform the action directly and do not include the reasoning
 Only return PLAIN TEXT
 `
+
+/**
+ * Generates one or more images or describes a single image based on the provided `ImageRequestBody`.
+ *
+ * Image Server Action that calls the third-party API directly on the server. This avoids calling the Next.js API route handler allowing for performant Server Components.
+ * @link https://nextjs.org/docs/app/building-your-application/data-fetching/patterns Next.js Data Fetching Patterns and Best Practices
+ * @returns {Promise<ImageGenerationResponse<string | string[]>>} A single string or an array of strings (if `n` > 1) containing the text description or the base64 string or URL of the generated image.
+ */
 export async function getImage(
+	/**
+	 * @link ImageRequestBody
+	 */
 	request: Omit<ImageRequestBody, 'n'> & { n?: 1 | 0 | null },
+	/**
+	 * @link ImageOptions
+	 */
 	options?: ImageOptions
 ): Promise<ImageGenerationResponse<string>>
 export async function getImage(

--- a/packages/fullstack-components/src/handlers/image/models.ts
+++ b/packages/fullstack-components/src/handlers/image/models.ts
@@ -3,11 +3,15 @@ import OpenAI from 'openai'
 export type ImageGenerationOptions = Partial<OpenAI.ImageGenerateParams>
 
 /**
- * @extends `Partial<OpenAI.ImageGenerateParams>`
- * @see `openai` for full `OpenAI.ImageGenerateParams` type information.
+ * Image generation or description request body. See OpenAI.ImageGenerateParams for full type information.
+ * @extends Partial<OpenAI.ImageGenerateParams>
+ * @link https://www.npmjs.com/package/openai `openai` for full `OpenAI.ImageGenerateParams` type information.
  */
 export interface ImageRequestBody extends ImageGenerationOptions {
-	/** URL to image to describe */
+	/**
+	 * An absolute URL to the image to describe.
+	 * @example 'https://absolute-cat-url/tabbycat.jpg'
+	 */
 	src?: string
 }
 

--- a/packages/fullstack-components/src/handlers/image/models.ts
+++ b/packages/fullstack-components/src/handlers/image/models.ts
@@ -2,6 +2,10 @@ import OpenAI from 'openai'
 
 export type ImageGenerationOptions = Partial<OpenAI.ImageGenerateParams>
 
+/**
+ * @extends `Partial<OpenAI.ImageGenerateParams>`
+ * @see `openai` for full `OpenAI.ImageGenerateParams` type information.
+ */
 export interface ImageRequestBody extends ImageGenerationOptions {
 	/** URL to image to describe */
 	src?: string
@@ -12,6 +16,9 @@ export type ImageResponse<T> = T extends 1 | null | undefined
 	: string[]
 
 export type ImageOptions = {
+	/**
+	 * @default `process.env.OPENAI_API_KEY`.
+	 */
 	openAiApiKey?: string
 }
 

--- a/packages/fullstack-components/src/handlers/image/useImage.ts
+++ b/packages/fullstack-components/src/handlers/image/useImage.ts
@@ -7,6 +7,14 @@ import {
 } from '../../hooks/useRequest'
 import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 
+/**
+ * Image client hook
+ */
+export interface UseImageParameters {
+	body: ImageRequestBody
+	config?: UseRequestConsumerConfig<ImageRequestBody>
+}
+
 export function useImage(
 	body: ImageRequestBody & { n?: 1 | 0 | null },
 	config?: UseRequestConsumerConfig<ImageRequestBody>

--- a/packages/fullstack-components/src/handlers/image/useImage.ts
+++ b/packages/fullstack-components/src/handlers/image/useImage.ts
@@ -8,15 +8,18 @@ import {
 import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 
 /**
- * Image client hook
+ * A client-side fetch handler hook for generating one or more images or describing a single image based on the provided `ImageRequestBody`.
+ * @see `ApiUrlEnum.image`
  */
-export interface UseImageParameters {
-	body: ImageRequestBody
-	config?: UseRequestConsumerConfig<ImageRequestBody>
-}
-
 export function useImage(
+	/**
+	 * @link ImageRequestBody
+	 */
 	body: ImageRequestBody & { n?: 1 | 0 | null },
+	/**
+	 * Fetch utility hook request options without the `fetcher`. Allows for overriding the default `request` config.
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+	 */
 	config?: UseRequestConsumerConfig<ImageRequestBody>
 ): ReturnType<typeof useRequest<string, ImageRequestBody>>
 export function useImage(

--- a/packages/fullstack-components/src/handlers/notFoundEnhancer/fetchers.ts
+++ b/packages/fullstack-components/src/handlers/notFoundEnhancer/fetchers.ts
@@ -7,10 +7,20 @@ import type {
 } from './models'
 
 /**
- * Not found enhancement request
+ * Finds the closest matching page to the URL that was not found, and uses the contents of your website URLs to create a helpful message.
+ *
+ * Not found enhancement client-side fetch handler that calls the internal Next.js API route handler, then the third-party API. Best used for Client Components and functionality.
+ * @see `ApiUrlEnum.notFoundEnhancer`
  */
 export function fetchNotFoundEnhancement(
+	/**
+	 * @link NotFoundEnhancerRequestBody
+	 */
 	body: NotFoundEnhancerRequestBody,
+	/**
+	 * Fetch utility request options without the `body`
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+	 */
 	config?: RequestConfigOnly
 ) {
 	return request<NotFoundEnhancerResponse>(ApiUrlEnum.notFoundEnhancer, {

--- a/packages/fullstack-components/src/handlers/notFoundEnhancer/models.ts
+++ b/packages/fullstack-components/src/handlers/notFoundEnhancer/models.ts
@@ -1,6 +1,7 @@
 export interface NotFoundEnhancerRequestBody {
 	/**
 	 * The full URL being visited.
+	 * @example 'https://example.com/this-page-does-not-exist'
 	 */
 	requestedUrl?: string
 }
@@ -8,10 +9,12 @@ export interface NotFoundEnhancerRequestBody {
 export type NotFoundEnhancerResponse = {
 	/**
 	 * A helpful message derived from inspecting the `requestedUrl` and sitemap.
+	 * @example 'This page does not exist, if you are looking for the about page, you can find it at https://example.com/about'
 	 */
 	generatedContent: string
 	/**
 	 * A list of the most likely suitable URLs for the user to visit.
+	 * @example `['https://example.com/about', 'https://example.com/contact']`
 	 */
 	bestAlternateUrls: string[]
 }
@@ -19,6 +22,7 @@ export type NotFoundEnhancerResponse = {
 export type NotFoundEnhancerOptions = {
 	/**
 	 * The application site URL. Used to find the sitemap, and to construct alternate URLs.
+	 * @example 'https://example.com'
 	 */
 	siteUrl: string
 	/**

--- a/packages/fullstack-components/src/handlers/notFoundEnhancer/models.ts
+++ b/packages/fullstack-components/src/handlers/notFoundEnhancer/models.ts
@@ -1,14 +1,32 @@
-export class NotFoundEnhancerRequestBody {
+export interface NotFoundEnhancerRequestBody {
+	/**
+	 * The full URL being visited.
+	 */
 	requestedUrl?: string
 }
+
 export type NotFoundEnhancerResponse = {
+	/**
+	 * A helpful message derived from inspecting the `requestedUrl` and sitemap.
+	 */
 	generatedContent: string
+	/**
+	 * A list of the most likely suitable URLs for the user to visit.
+	 */
 	bestAlternateUrls: string[]
 }
+
 export type NotFoundEnhancerOptions = {
+	/**
+	 * The application site URL. Used to find the sitemap, and to construct alternate URLs.
+	 */
 	siteUrl: string
+	/**
+	 * @default `process.env.OPENAI_API_KEY`.
+	 */
 	openAiApiKey: string
 }
+
 export class NotFoundEnhancerError extends Error {
 	public rootCause: string
 

--- a/packages/fullstack-components/src/handlers/notFoundEnhancer/notFoundEnhancerContentGenerator.ts
+++ b/packages/fullstack-components/src/handlers/notFoundEnhancer/notFoundEnhancerContentGenerator.ts
@@ -11,8 +11,20 @@ export type ChatMessage = {
 	content: string
 }
 
+/**
+ * Uses the contents of your website URLs to create a helpful message that solves the user's intent or problem.
+ *
+ * Not Found Enhancement message Server Action that calls the third-party API directly on the server. This avoids calling the Next.js API route handler allowing for performant Server Components.
+ * @link https://nextjs.org/docs/app/building-your-application/data-fetching/patterns Next.js Data Fetching Patterns and Best Practices
+ */
 export async function getNotFoundContentGenerator(
+	/**
+	 * @link NotFoundEnhancerRequestBody
+	 */
 	request: NotFoundEnhancerRequestBody,
+	/**
+	 * @link NotFoundEnhancerOptions
+	 */
 	options: NotFoundEnhancerOptions
 ) {
 	'use server'

--- a/packages/fullstack-components/src/handlers/notFoundEnhancer/notFoundEnhancerSitemapSelector.ts
+++ b/packages/fullstack-components/src/handlers/notFoundEnhancer/notFoundEnhancerSitemapSelector.ts
@@ -11,8 +11,20 @@ export type ChatMessage = {
 	content: string
 }
 
+/**
+ * Finds the best alternative urls from the sitemap that could be what the user really wanted with their requested url.
+ *
+ * Not Found Enhancement best alternate urls Server Action that calls the third-party API directly on the server. This avoids calling the Next.js API route handler allowing for performant Server Components.
+ * @link https://nextjs.org/docs/app/building-your-application/data-fetching/patterns Next.js Data Fetching Patterns and Best Practices
+ */
 export async function getNotFoundSitemapSelector(
+	/**
+	 * @link NotFoundEnhancerRequestBody
+	 */
 	request: NotFoundEnhancerRequestBody,
+	/**
+	 * @link NotFoundEnhancerOptions
+	 */
 	options: NotFoundEnhancerOptions
 ) {
 	'use server'

--- a/packages/fullstack-components/src/handlers/notFoundEnhancer/sitemapParser.ts
+++ b/packages/fullstack-components/src/handlers/notFoundEnhancer/sitemapParser.ts
@@ -12,6 +12,7 @@ export async function sitemapFromCache(currentHost: string) {
 	return sitemapCache
 }
 
+// TODO: make the file path configurable
 async function loadAndParseSitemapToListOfUrls(
 	currentHost: string
 ): Promise<string[]> {

--- a/packages/fullstack-components/src/handlers/notFoundEnhancer/useNotFoundEnhancement.ts
+++ b/packages/fullstack-components/src/handlers/notFoundEnhancer/useNotFoundEnhancement.ts
@@ -10,10 +10,21 @@ import {
 } from '../../hooks/useRequest'
 import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 
-export const useNotFoundEnhancement = (
-	/** Optional - `requestedUrl` default is `window.location.href`  */
-	body?: NotFoundEnhancerRequestBody,
+/**
+ * Not found enhancer client hook
+ */
+export interface UseNotFoundEnhancementParameters {
+	/**
+	 * `requestedUrl`
+	 * @default `window.location.href`
+	 */
+	body?: NotFoundEnhancerRequestBody
 	config?: UseRequestConsumerConfig<NotFoundEnhancerRequestBody>
+}
+
+export const useNotFoundEnhancement = (
+	body?: UseNotFoundEnhancementParameters['body'],
+	config?: UseNotFoundEnhancementParameters['config']
 ) => {
 	return useRequest<NotFoundEnhancerResponse>(ApiUrlEnum.notFoundEnhancer, {
 		body: {

--- a/packages/fullstack-components/src/handlers/notFoundEnhancer/useNotFoundEnhancement.ts
+++ b/packages/fullstack-components/src/handlers/notFoundEnhancer/useNotFoundEnhancement.ts
@@ -11,21 +11,22 @@ import {
 import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 
 /**
- * Not found enhancer client hook
+ * A client-side fetch handler hook that finds the closest matching page to the URL that was not found, and uses the contents of your website URLs to create a helpful message.
+ * @default `requestedUrl` is set to `window.location.href`
+ * @see `ApiUrlEnum.notFoundEnhancer`
  */
-export interface UseNotFoundEnhancementParameters {
+export function useNotFoundEnhancement(
 	/**
-	 * `requestedUrl`
-	 * @default `window.location.href`
+	 * @link NotFoundEnhancerRequestBody
+	 * @default `requestedUrl` is set to `window.location.href`
 	 */
-	body?: NotFoundEnhancerRequestBody
+	body?: NotFoundEnhancerRequestBody,
+	/**
+	 * Fetch utility hook request options without the `fetcher`. Allows for overriding the default `request` config.
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+	 */
 	config?: UseRequestConsumerConfig<NotFoundEnhancerRequestBody>
-}
-
-export const useNotFoundEnhancement = (
-	body?: UseNotFoundEnhancementParameters['body'],
-	config?: UseNotFoundEnhancementParameters['config']
-) => {
+) {
 	return useRequest<NotFoundEnhancerResponse>(ApiUrlEnum.notFoundEnhancer, {
 		body: {
 			requestedUrl: typeof window !== 'undefined' && window.location.href,

--- a/packages/fullstack-components/src/handlers/prompt/fetchers.ts
+++ b/packages/fullstack-components/src/handlers/prompt/fetchers.ts
@@ -1,14 +1,25 @@
 'use client'
 import { request, type RequestConfigOnly } from '../../utils/request'
 import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
-import type { PromptResponse, PromptRequestBody } from './models'
+import type { PromptResponseBody, PromptRequestBody } from './models'
 
 /**
- * Prompt fetcher
+ * Answers a `prompt` or an array of `messages` and returns the response as-is.
+ *
+ * Prompt client-side fetch handler that calls the internal Next.js API route handler, then the third-party API. Best used for Client Components and functionality.
+ * @see `ApiUrlEnum.prompt`
+ * @returns {Promise<PromptResponseBody>} JSON response
  */
 export function fetchPrompt(
+	/**
+	 * @link PromptRequestBody
+	 */
 	body: PromptRequestBody,
+	/**
+	 * Fetch utility request options without the `body`
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+	 */
 	config?: RequestConfigOnly
 ) {
-	return request<PromptResponse>(ApiUrlEnum.prompt, { body, ...config })
+	return request<PromptResponseBody>(ApiUrlEnum.prompt, { body, ...config })
 }

--- a/packages/fullstack-components/src/handlers/prompt/models.ts
+++ b/packages/fullstack-components/src/handlers/prompt/models.ts
@@ -4,17 +4,19 @@ export interface PromptRequestBody {
 	/**
 	 * A text description of the desired output.
 	 * Used to send a simple `user` message to chat completion.
+	 * @example 'A blog post about the best way to cook a steak'
 	 */
 	prompt?: string
 	/**
 	 * A list of chat completion messages comprising a conversation.
 	 * `messages` are inserted before `prompt` if both are provided.
-	 * @see `openai` for full `OpenAI.ChatCompletionMessageParam` type information.
+	 * @example `[{ role: 'system', content: 'You are a professional chef and esteemed poet. You answer cooking questions with poetry and rhyme.' }, { role: 'user', content: 'What is the best way to cook a steak?'}]`
+	 * @link https://www.npmjs.com/package/openai `openai` for full `OpenAI.ChatCompletionMessageParam` type information.
 	 */
 	messages?: ChatMessage[]
 }
 
-export type PromptResponse = string
+export type PromptResponseBody = string
 
 export type PromptOptions = {
 	/**

--- a/packages/fullstack-components/src/handlers/prompt/models.ts
+++ b/packages/fullstack-components/src/handlers/prompt/models.ts
@@ -1,15 +1,25 @@
 import type { ChatMessage } from '../../types/ChatMessage'
 
-export class PromptRequestBody {
-	/** Used to send a simple `user` message to chat completion */
+export interface PromptRequestBody {
+	/**
+	 * A text description of the desired output.
+	 * Used to send a simple `user` message to chat completion.
+	 */
 	prompt?: string
-	/** Messages to send to chat completion. `messages` are inserted before `prompt` if both are provided. */
+	/**
+	 * A list of chat completion messages comprising a conversation.
+	 * `messages` are inserted before `prompt` if both are provided.
+	 * @see `openai` for full `OpenAI.ChatCompletionMessageParam` type information.
+	 */
 	messages?: ChatMessage[]
 }
 
 export type PromptResponse = string
 
 export type PromptOptions = {
+	/**
+	 * @default `process.env.OPENAI_API_KEY`.
+	 */
 	openAiApiKey?: string
 }
 

--- a/packages/fullstack-components/src/handlers/prompt/promptClient.ts
+++ b/packages/fullstack-components/src/handlers/prompt/promptClient.ts
@@ -3,8 +3,21 @@ import { OPENAI_API_KEY } from '../../utils/constants'
 import type { PromptRequestBody, PromptOptions } from './models'
 import type { ChatMessage } from '../../types/ChatMessage'
 
+/**
+ * Answers a `prompt` or an array of `messages` and returns the response as-is.
+ *
+ * Prompt Server Action that calls the third-party API directly on the server. This avoids calling the Next.js API route handler allowing for performant Server Components.
+ * @link https://nextjs.org/docs/app/building-your-application/data-fetching/patterns Next.js Data Fetching Patterns and Best Practices
+ * @returns {Promise<ChatGptCompletionResponse<string>>} response
+ */
 export async function getPrompt(
+	/**
+	 * @link PromptRequestBody
+	 */
 	request: PromptRequestBody,
+	/**
+	 * @link PromptOptions
+	 */
 	options?: PromptOptions
 ) {
 	'use server'

--- a/packages/fullstack-components/src/handlers/prompt/usePrompt.ts
+++ b/packages/fullstack-components/src/handlers/prompt/usePrompt.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import type { PromptResponse, PromptRequestBody } from './models'
+import type { PromptResponseBody, PromptRequestBody } from './models'
 import {
 	useRequest,
 	type UseRequestConsumerConfig,
@@ -8,21 +8,21 @@ import {
 import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 
 /**
- * Prompt client hook
+ * A client-side fetch handler hook that answers a `prompt` or an array of `messages` and returns the response as-is.
+ * @see `ApiUrlEnum.prompt`
  */
-export interface UsePromptParameters {
+export function usePrompt(
 	/**
-	 * @see `PromptRequestBody`
+	 * @link PromptRequestBody
 	 */
-	body: PromptRequestBody
+	body: PromptRequestBody,
+	/**
+	 * Fetch utility hook request options without the `fetcher`. Allows for overriding the default `request` config.
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+	 */
 	config?: UseRequestConsumerConfig<PromptRequestBody>
-}
-
-export const usePrompt = <T = PromptResponse>(
-	body: UsePromptParameters['body'],
-	config?: UsePromptParameters['config']
-) => {
-	return useRequest<T>(ApiUrlEnum.prompt, {
+) {
+	return useRequest<PromptResponseBody>(ApiUrlEnum.prompt, {
 		body,
 		...config,
 	})

--- a/packages/fullstack-components/src/handlers/prompt/usePrompt.ts
+++ b/packages/fullstack-components/src/handlers/prompt/usePrompt.ts
@@ -7,9 +7,20 @@ import {
 } from '../../hooks/useRequest'
 import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 
-export const usePrompt = <T = PromptResponse>(
-	body: PromptRequestBody,
+/**
+ * Prompt client hook
+ */
+export interface UsePromptParameters {
+	/**
+	 * @see `PromptRequestBody`
+	 */
+	body: PromptRequestBody
 	config?: UseRequestConsumerConfig<PromptRequestBody>
+}
+
+export const usePrompt = <T = PromptResponse>(
+	body: UsePromptParameters['body'],
+	config?: UsePromptParameters['config']
 ) => {
 	return useRequest<T>(ApiUrlEnum.prompt, {
 		body,

--- a/packages/fullstack-components/src/handlers/select/fetchers.ts
+++ b/packages/fullstack-components/src/handlers/select/fetchers.ts
@@ -4,10 +4,21 @@ import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 import type { SelectResponse, SelectRequestBody } from './models'
 
 /**
- * Select generation fetcher
+ * Generates a `label` and a list of options in `content` based on the provided `SelectRequestBody`.
+ *
+ * Select client-side fetch handler that calls the internal Next.js API route handler, then the third-party API. Best used for Client Components and functionality.
+ * @see `ApiUrlEnum.select`
+ * @returns {Promise<SelectResponse>} JSON response
  */
 export function fetchSelect(
+	/**
+	 * @link SelectRequestBody
+	 */
 	body: SelectRequestBody,
+	/**
+	 * Fetch utility request options without the `body`
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+	 */
 	config?: RequestConfigOnly
 ) {
 	return request<SelectResponse>(ApiUrlEnum.select, { body, ...config })

--- a/packages/fullstack-components/src/handlers/select/models.ts
+++ b/packages/fullstack-components/src/handlers/select/models.ts
@@ -1,24 +1,24 @@
-export class SelectRequestBody {
+export interface SelectRequestBody {
 	/**
-	 * Prompt for creating the select
+	 * A text description for creating the dropdown.
 	 * @example 'All the GMT time zones'
 	 * @example 'The nearest countries to Australia. Include a flag emoji in the label'
 	 */
 	prompt?: string
 	/**
-	 * What the purpose of the select is
+	 * A text description of the purpose of the dropdown.
 	 * @example 'Selecting your time zone'
 	 * @example 'Weekday selection'
 	 */
 	purpose?: string
 	/**
-	 * Additional context to pass to the prompt
+	 * A text description of additional context or information to help create the dropdown.
 	 * @example 'The time zone for Sydney should be selected'
 	 * @example 'Sort the list based on what's most popular'
 	 */
 	context?: string
 	/**
-	 * The number of items to aim for
+	 * The number of dropdown options or list items to create.
 	 */
 	count?: number
 }
@@ -51,6 +51,9 @@ export type SelectResponse = {
 }
 
 export type SelectOptions = {
+	/**
+	 * @default `process.env.OPENAI_API_KEY`.
+	 */
 	openAiApiKey?: string
 }
 

--- a/packages/fullstack-components/src/handlers/select/models.ts
+++ b/packages/fullstack-components/src/handlers/select/models.ts
@@ -2,51 +2,53 @@ export interface SelectRequestBody {
 	/**
 	 * A text description for creating the dropdown.
 	 * @example 'All the GMT time zones'
-	 * @example 'The nearest countries to Australia. Include a flag emoji in the label'
 	 */
 	prompt?: string
 	/**
 	 * A text description of the purpose of the dropdown.
 	 * @example 'Selecting your time zone'
-	 * @example 'Weekday selection'
 	 */
 	purpose?: string
 	/**
 	 * A text description of additional context or information to help create the dropdown.
 	 * @example 'The time zone for Sydney should be selected'
-	 * @example 'Sort the list based on what's most popular'
 	 */
 	context?: string
 	/**
 	 * The number of dropdown options or list items to create.
+	 * @example 10
 	 */
 	count?: number
 }
 
-export type SelectRequestOptions = Omit<SelectRequestBody, 'prompt'> &
-	Required<Pick<SelectRequestBody, 'prompt'>>
-
 export type SelectResponseItem = {
 	/**
-	 * Readable label for the option
+	 * Text to display in the dropdown option.
+	 * @example 'GMT+10:00 Brisbane, Melbourne, Sydney'
 	 */
 	label: string
 	/**
-	 * Value for the option
+	 * Text value to return when the option is selected.
+	 * @example 'Australia/Sydney'
 	 */
 	value: string
 	/**
-	 * Whether the option is selected
+	 * Whether the option is selected by default.
+	 * @example true
 	 */
 	selected?: true
 }
 
 export type SelectResponse = {
 	/**
-	 * An array of options to display in the dropdown
+	 * An array of options to list or display in a dropdown.
+	 * @example [{ label: 'GMT+10:00 Brisbane, Melbourne, Sydney', value: 'Australia/Sydney', selected: true }, { label: 'GMT+12:00 Auckland, Wellington', value: 'Pacific/Auckland' }, ...]
 	 */
 	content: Array<SelectResponseItem>
-	/** The overall associated label for the dropdown */
+	/**
+	 * The overall associated label for the dropdown.
+	 * @example 'Select Time Zone (GMT)'
+	 */
 	label: string
 }
 

--- a/packages/fullstack-components/src/handlers/select/selectClient.ts
+++ b/packages/fullstack-components/src/handlers/select/selectClient.ts
@@ -17,8 +17,21 @@ Make the dropdown options diverse and relevant for the given context
 Do not include the reasoning
 `
 
+/**
+ * Generates a list of options to list or display in a dropdown.
+ *
+ * Select Server Action that calls the third-party API directly on the server. This avoids calling the Next.js API route handler allowing for performant Server Components.
+ * @link https://nextjs.org/docs/app/building-your-application/data-fetching/patterns Next.js Data Fetching Patterns and Best Practices
+ * @returns {Promise<ChatGptCompletionResponse<string>>} JSON response
+ */
 export async function getSelect(
+	/**
+	 * @link SelectRequestBody
+	 */
 	request: SelectRequestBody,
+	/**
+	 * @link SelectOptions
+	 */
 	options?: SelectOptions
 ) {
 	'use server'

--- a/packages/fullstack-components/src/handlers/select/useSelect.ts
+++ b/packages/fullstack-components/src/handlers/select/useSelect.ts
@@ -8,17 +8,20 @@ import {
 import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 
 /**
- * Select client hook
+ * A client-side fetch handler hook for generating a `label` and a list of options in `content` based on the provided `SelectRequestBody`.
+ * @see `ApiUrlEnum.select`
  */
-export interface UseSelectParameters {
-	body: SelectRequestBody
+export function useSelect(
+	/**
+	 * @link SelectRequestBody
+	 */
+	body: SelectRequestBody,
+	/**
+	 * Fetch utility hook request options without the `fetcher`. Allows for overriding the default `request` config.
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+	 */
 	config?: UseRequestConsumerConfig<SelectRequestBody>
-}
-
-export const useSelect = (
-	body: UseSelectParameters['body'],
-	config?: UseSelectParameters['config']
-) => {
+) {
 	return useRequest<SelectResponse>(ApiUrlEnum.select, {
 		body,
 		...config,

--- a/packages/fullstack-components/src/handlers/select/useSelect.ts
+++ b/packages/fullstack-components/src/handlers/select/useSelect.ts
@@ -7,9 +7,17 @@ import {
 } from '../../hooks/useRequest'
 import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 
-export const useSelect = (
-	body: SelectRequestBody,
+/**
+ * Select client hook
+ */
+export interface UseSelectParameters {
+	body: SelectRequestBody
 	config?: UseRequestConsumerConfig<SelectRequestBody>
+}
+
+export const useSelect = (
+	body: UseSelectParameters['body'],
+	config?: UseSelectParameters['config']
 ) => {
 	return useRequest<SelectResponse>(ApiUrlEnum.select, {
 		body,

--- a/packages/fullstack-components/src/handlers/text/fetchers.ts
+++ b/packages/fullstack-components/src/handlers/text/fetchers.ts
@@ -3,13 +3,16 @@ import { request, type RequestConfigOnly } from '../../utils/request'
 import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 import { ordinal } from '../../utils/lang'
 import { renderTreeToString } from './renderTreeToString'
-import type { TextProps, TextResponse } from './models'
+import type { TextParameters, TextResponse } from './models'
 
 /**
  * Text generation fetcher
  * Transforms `content` react trees to a HTML string
  */
-export async function fetchText(props: TextProps, config?: RequestConfigOnly) {
+export async function fetchText(
+	props: TextParameters,
+	config?: RequestConfigOnly
+) {
 	const { content: rawContent, grade: rawGrade, ...options } = props || {}
 	const grade =
 		typeof rawGrade === 'number' ? `${ordinal(rawGrade)}-grade` : rawGrade

--- a/packages/fullstack-components/src/handlers/text/fetchers.ts
+++ b/packages/fullstack-components/src/handlers/text/fetchers.ts
@@ -6,14 +6,24 @@ import { renderTreeToString } from './renderTreeToString'
 import type { TextParameters, TextResponse } from './models'
 
 /**
- * Text generation fetcher
- * Transforms `content` react trees to a HTML string
+ * Rewrites, creates, edits and modifies text content for the web provided by the user. Handles plain text `content` or transforms React trees to a HTML string. Transforms numeric `grade` values to a string ordinal, e.g. `1` to `1st-grade`.
+ *
+ * Text generation client-side fetch handler that calls the internal Next.js API route handler, then the third-party API. Best used for Client Components and functionality.
+ * @see `ApiUrlEnum.text`
  */
 export async function fetchText(
-	props: TextParameters,
+	/**
+	 * TextParameters extends TextRequestBody to allow for `content` to be a React tree.
+	 * @link TextRequestBody
+	 */
+	body: TextParameters,
+	/**
+	 * Fetch utility request options without the `body`
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+	 */
 	config?: RequestConfigOnly
 ) {
-	const { content: rawContent, grade: rawGrade, ...options } = props || {}
+	const { content: rawContent, grade: rawGrade, ...options } = body || {}
 	const grade =
 		typeof rawGrade === 'number' ? `${ordinal(rawGrade)}-grade` : rawGrade
 	const content = await renderTreeToString(rawContent)

--- a/packages/fullstack-components/src/handlers/text/models.ts
+++ b/packages/fullstack-components/src/handlers/text/models.ts
@@ -2,50 +2,68 @@ import type { ReactNode } from 'react'
 import type { Range } from '../../types/helpers'
 
 export interface TextRequestBody {
-	/** A text string, stringified HTML or a stringified React tree of the content to re/write. */
+	/**
+	 * A text string, stringified HTML or a stringified React tree of the content to re/write.
+	 * @note If a React tree is provided, use `fetchText`, `useText` or manually transform the tree to a HTML string.
+	 * @example 'Quantum formalism and the uncertainty principle'
+	 */
 	content?: string
-	/** A text description of how to re/write the `content`. */
+	/**
+	 * A text description of how to re/write the `content`.
+	 * @example 'Summarize the following text in a single, simple sentence.'
+	 */
 	prompt?: string
 	/**
 	 * Enforce a content type for the output.
-	 * Can be used to transform from one type to another.
-	 * If not defined, the content type should match the input.
+	 * Can be used to transform from one type to another. If not defined, the content type should match the input.
+	 * @example 'markdown'
 	 */
 	type?: 'text' | 'markdown' | 'HTML'
 	/**
 	 * A text description defining the tone of voice of the content.
 	 * If not defined, the tone of the input content is matched as closely as possible.
+	 * @example 'friendly and whimsical'
 	 */
 	tone?: string
 	/**
 	 * A number between 0-100 of how heavily the content is modified.
 	 * 0 returns the original content, 100 completely rewrites the content.
+	 * @example 50
 	 */
 	strength?: Range<0, 100>
 	/**
-	 * A number based school grades setting the readability level.
-	 * Higher numbers creates more complex text which is harder to read.
-	 * Lower numbers creates more readable text using simpler words.
+	 * A number or string that sets the readability level based on school grades.
+	 * Higher numbers creates more complex and harder to read text.
+	 * Lower numbers creates more readable text with simpler words.
+	 * @example 5
+	 * @example '5th-grade'
 	 */
 	grade?: number | string
 	/**
 	 * A number or the *desired* max amount of output text characters, not counting HTML markup if present.
 	 * @note Results vary and may subceed or exceed the desired amount of characters.
+	 * @example 1000
 	 */
 	max?: number
 	/**
 	 * A number of the *desired* minimum amount of output text characters, not counting HTML markup if present.
 	 * @note Results vary and may subceed or exceed the desired amount of characters.
+	 * @example 100
 	 */
 	min?: number
 }
 
 /**
- * Text component and hook props
- * @extends Omit<TextRequestBody, 'content'>
+ * Text component and hook props.
+ * @link TextRequestBody
+ * @extends TextRequestBody
  */
 export interface TextParameters extends Omit<TextRequestBody, 'content'> {
-	/** Content to re/write. Plain text or a React tree. */
+	/**
+	 * Content to re/write. Plain text or a React tree.
+	 * @note If a React tree is provided, use `fetchText`, `useText` or manually transform the tree to a HTML string.
+	 * @example `<Title>Quantum formalism and the uncertainty principle</Title>`
+	 */
 	content: ReactNode
 }
 
@@ -57,9 +75,15 @@ export type TextOptions = {
 }
 
 export type TextResponse = {
-	/** The format of `content`. */
+	/**
+	 * The content type of the re/written content.
+	 * @example 'HTML'
+	 */
 	type: 'text' | 'markdown' | 'HTML'
-	/** The re/written content stringified as the `type`. */
+	/**
+	 * The re/written content.
+	 * @example '<h1>Quantum formalism and the uncertainty principle</h1>'
+	 */
 	content: string
 }
 

--- a/packages/fullstack-components/src/handlers/text/models.ts
+++ b/packages/fullstack-components/src/handlers/text/models.ts
@@ -1,49 +1,65 @@
 import type { ReactNode } from 'react'
 import type { Range } from '../../types/helpers'
 
-export type TextTypes = 'text' | 'markdown' | 'HTML'
-
-export class TextRequestBody {
-	/** Content to rewrite */
+export interface TextRequestBody {
+	/** A text string, stringified HTML or a stringified React tree of the content to re/write. */
 	content?: string
-	/** Instructions on how to re/write the content */
+	/** A text description of how to re/write the `content`. */
 	prompt?: string
 	/**
 	 * Enforce a content type for the output.
 	 * Can be used to transform from one type to another.
 	 * If not defined, the content type should match the input.
 	 */
-	type?: TextTypes
+	type?: 'text' | 'markdown' | 'HTML'
 	/**
-	 * Sets the tone of voice of the output.
+	 * A text description defining the tone of voice of the content.
 	 * If not defined, the tone of the input content is matched as closely as possible.
 	 */
 	tone?: string
 	/**
-	 * How heavily content is rewritten.
-	 * This is a number or array of numbers from 0-100.
+	 * A number between 0-100 of how heavily the content is modified.
 	 * 0 returns the original content, 100 completely rewrites the content.
 	 */
 	strength?: Range<0, 100>
-	/** Readability level based school grades.  */
+	/**
+	 * A number based school grades setting the readability level.
+	 * Higher numbers creates more complex text which is harder to read.
+	 * Lower numbers creates more readable text using simpler words.
+	 */
 	grade?: number | string
-	/** Max amount of output text characters, not counting HTML markup if present. */
+	/**
+	 * A number or the *desired* max amount of output text characters, not counting HTML markup if present.
+	 * @note Results vary and may subceed or exceed the desired amount of characters.
+	 */
 	max?: number
-	/** Minimum amount of output text characters, not counting HTML markup if present. */
+	/**
+	 * A number of the *desired* minimum amount of output text characters, not counting HTML markup if present.
+	 * @note Results vary and may subceed or exceed the desired amount of characters.
+	 */
 	min?: number
 }
 
-export interface TextProps extends Omit<TextRequestBody, 'content'> {
-	/** Content to rewrite. Plain text or a react tree */
+/**
+ * Text component and hook props
+ * @extends Omit<TextRequestBody, 'content'>
+ */
+export interface TextParameters extends Omit<TextRequestBody, 'content'> {
+	/** Content to re/write. Plain text or a React tree. */
 	content: ReactNode
 }
 
 export type TextOptions = {
+	/**
+	 * @default `process.env.OPENAI_API_KEY`.
+	 */
 	openAiApiKey?: string
 }
 
 export type TextResponse = {
-	type: TextTypes
+	/** The format of `content`. */
+	type: 'text' | 'markdown' | 'HTML'
+	/** The re/written content stringified as the `type`. */
 	content: string
 }
 

--- a/packages/fullstack-components/src/handlers/text/renderTreeToString.ts
+++ b/packages/fullstack-components/src/handlers/text/renderTreeToString.ts
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react'
 
 /**
- * Transforms a react tree to a HTML string
+ * Transforms a React tree to a HTML string.
+ * Works both on the server and client.
  */
 export async function renderTreeToString(content: ReactNode) {
 	// Server only

--- a/packages/fullstack-components/src/handlers/text/textClient.ts
+++ b/packages/fullstack-components/src/handlers/text/textClient.ts
@@ -19,7 +19,23 @@ If the user's HTML text has HTML heading elements (h1, h2, h3 etc.) and your rew
 If the user asks you to shorten, reduce or otherwise summarize the text, make sure you REALLY SHORTEN the text. You are allowed to omit paragraphs to achieve this. You should retain at least one heading if present in the input (you can modify this), you can omit or shorten the remaining headings.
 `
 
-export async function getText(request: TextRequestBody, options?: TextOptions) {
+/**
+ * Rewrites, creates, edits and modifies text content for the web provided by the user.
+ *
+ * Text Server Action that calls the third-party API directly on the server. This avoids calling the Next.js API route handler allowing for performant Server Components.
+ * @link https://nextjs.org/docs/app/building-your-application/data-fetching/patterns Next.js Data Fetching Patterns and Best Practices
+ * @returns {Promise<ChatGptCompletionResponse<string>} JSON response
+ */
+export async function getText(
+	/**
+	 * @link TextRequestBody
+	 */
+	request: TextRequestBody,
+	/**
+	 * @link TextOptions
+	 */
+	options?: TextOptions
+) {
 	'use server'
 	console.log('handling `getText` request', request)
 	const content: ChatMessage['content'] = []

--- a/packages/fullstack-components/src/handlers/text/useText.ts
+++ b/packages/fullstack-components/src/handlers/text/useText.ts
@@ -9,17 +9,21 @@ import { fetchText } from './fetchers'
 import type { TextRequestBody, TextResponse, TextParameters } from './models'
 
 /**
- * Text client hook
+ * A client-side fetch handler hook that generates text. Handles plain text `content` or transforms React trees to a HTML string.
+ * @see `ApiUrlEnum.text`
  */
-export interface UseTextParameters {
-	body: TextParameters
+export function useText(
+	/**
+	 * TextParameters extends TextRequestBody to allow for `content` to be a React tree.
+	 * @link TextRequestBody
+	 */
+	body: TextParameters,
+	/**
+	 * Fetch utility hook request options without the `fetcher`. Allows for overriding the default `request` config.
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+	 */
 	config?: UseRequestConsumerConfig<TextRequestBody>
-}
-
-export const useText = (
-	body: UseTextParameters['body'],
-	config?: UseTextParameters['config']
-) => {
+) {
 	return useRequest<TextResponse>(ApiUrlEnum.text, {
 		...config,
 		fetcher: () => fetchText(body),

--- a/packages/fullstack-components/src/handlers/text/useText.ts
+++ b/packages/fullstack-components/src/handlers/text/useText.ts
@@ -6,14 +6,22 @@ import {
 } from '../../hooks/useRequest'
 import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
 import { fetchText } from './fetchers'
-import type { TextRequestBody, TextResponse, TextProps } from './models'
+import type { TextRequestBody, TextResponse, TextParameters } from './models'
+
+/**
+ * Text client hook
+ */
+export interface UseTextParameters {
+	body: TextParameters
+	config?: UseRequestConsumerConfig<TextRequestBody>
+}
 
 export const useText = (
-	props: TextProps,
-	config?: UseRequestConsumerConfig<TextRequestBody>
+	body: UseTextParameters['body'],
+	config?: UseTextParameters['config']
 ) => {
 	return useRequest<TextResponse>(ApiUrlEnum.text, {
 		...config,
-		fetcher: () => fetchText(props),
+		fetcher: () => fetchText(body),
 	})
 }

--- a/packages/fullstack-components/src/hooks/useRequest.ts
+++ b/packages/fullstack-components/src/hooks/useRequest.ts
@@ -4,12 +4,18 @@ import { useState, useEffect, useRef } from 'react'
 import { request } from '../utils/request'
 import type { RequestConfig } from '../types'
 
-/** Fetch request config initialiser in addition to the `baseUrl` */
+/**
+ * Fetch request config initialiser in addition to the `baseUrl`.
+ * @extends `RequestConfig`
+ */
 export type UseRequestConfig<
 	TResponse = unknown,
 	Tbody = unknown,
 > = RequestConfig<Tbody> & {
-	/** Whether the hook should run or not */
+	/**
+	 * Enables the fetch call.
+	 * @default `true`
+	 */
 	isEnabled?: boolean
 	/** Custom fetcher function enabling replacement of the built-in `request` in `requestData`  */
 	fetcher?: (
@@ -18,7 +24,10 @@ export type UseRequestConfig<
 	) => Promise<TResponse>
 }
 
-/** Config for hooks consuming `useRequest` */
+/**
+ * Config for hooks consuming `useRequest`
+ * @extends `UseRequestConfig`
+ */
 export type UseRequestConsumerConfig<Tbody = unknown> = Omit<
 	UseRequestConfig<unknown, Tbody>,
 	'fetcher'

--- a/packages/fullstack-components/src/hooks/useRequest.ts
+++ b/packages/fullstack-components/src/hooks/useRequest.ts
@@ -6,7 +6,7 @@ import type { RequestConfig } from '../types'
 
 /**
  * Fetch request config initialiser in addition to the `baseUrl`.
- * @extends `RequestConfig`
+ * @see RequestConfig
  */
 export type UseRequestConfig<
 	TResponse = unknown,
@@ -26,7 +26,7 @@ export type UseRequestConfig<
 
 /**
  * Config for hooks consuming `useRequest`
- * @extends `UseRequestConfig`
+ * @see UseRequestConfig
  */
 export type UseRequestConsumerConfig<Tbody = unknown> = Omit<
 	UseRequestConfig<unknown, Tbody>,
@@ -48,10 +48,17 @@ const requestData = <TResponse = unknown, Tbody = unknown>(
 	return request<TResponse, Tbody>(url, requestConfig)
 }
 
+/**
+ * Fetch utility hook for calling internal Next.js API route handlers.
+ * Handles loading, error and data states.
+ */
 export const useRequest = <TResponse = unknown, Tbody = unknown>(
 	/** Relative API url */
 	url: string,
-	/** Fetch request config initialiser in addition to the `baseUrl` */
+	/**
+	 * Fetch request config initialiser in addition to the `baseUrl`
+	 * @link UseRequestConfig
+	 */
 	config: UseRequestConfig<TResponse, Tbody>
 ) => {
 	const { isEnabled = true, ...requestConfig } = config

--- a/packages/fullstack-components/src/imageGenerationService.ts
+++ b/packages/fullstack-components/src/imageGenerationService.ts
@@ -14,13 +14,19 @@ export type ImageGenerationOptions = Omit<
 	OpenAI.ImageGenerateParams,
 	'model' | 'prompt'
 > & {
+	/**
+	 * @default `process.env.OPENAI_API_KEY`.
+	 */
 	openAIApiKey: string
+	/**
+	 * The model to use for image generation.
+	 */
 	model?: OpenAI.ImageGenerateParams['model']
 }
 
 /**
  * Image generation service
- * Defaults to base64 data URIs
+ * @default base64 data URIs
  */
 export async function runImageGeneration(
 	prompt: string,

--- a/packages/fullstack-components/src/types/Image.ts
+++ b/packages/fullstack-components/src/types/Image.ts
@@ -3,49 +3,66 @@ import { type ImageProps as NextImageProps } from 'next/image'
 import type { SyntheticEvent } from 'react'
 import type { ImageResponse } from '../handlers/image/models'
 
-export type ImageGenerationOptions = Partial<
-	Omit<OpenAI.ImageGenerateParams, 'n'>
->
-
+/**
+ * Props specific to describing an image.
+ * @extends `Omit<NextImageProps, 'src' | 'alt' | 'onLoad' | 'onError'>`
+ * @see `next/image` for full `NextImageProps` type information.
+ */
 export interface ImageDescribeProps
 	extends Omit<NextImageProps, 'src' | 'alt' | 'onLoad' | 'onError'> {
 	/**
 	 * URL to the image to describe. Generates `alt` text.
-	 * The `alt` text is then passed to the image and returned in `onLoad`
+	 * The `alt` text is then passed to the image and returned in `onLoad`.
 	 */
 	src: string
 	/**
-	 * Whether or not to render the result string adjacent to the image
+	 * Shows the image description text adjacent to the image.
 	 */
 	showResult?: boolean
 	/**
 	 * Callback function invoked once the image is completely loaded and the `placeholder` has been removed.
-	 * Returns the `event`, description `response` and the original `src`
 	 */
-	onLoad?: ImageDescribeCallback
-	/** Callback function that is invoked if the image fails to load. */
-	onError?: ImageDescribeCallback
+	onLoad?: (
+		/** A React `HTMLImageElement` event object with no additional properties. */
+		event: SyntheticEvent<HTMLImageElement, Event> | undefined,
+		/** A text description response of the image. */
+		response?: ImageResponse<1> | undefined,
+		/** Source of the image being described. */
+		src?: string
+	) => void
+	/**
+	 * Callback function that is invoked if the image fails to load.
+	 */
+	onError?: (
+		/** A React `HTMLImageElement` event object with no additional properties. */
+		event: SyntheticEvent<HTMLImageElement, Event> | undefined,
+		/** A text description response of the image. */
+		response?: ImageResponse<1> | undefined,
+		/** Source of the image being described. */
+		src?: string
+	) => void
 }
 
-export type ImageDescribeCallback = (
-	event: SyntheticEvent<HTMLImageElement, Event> | undefined,
-	/** Image description response */
-	response?: ImageResponse<1>,
-	/** Image description src */
-	src?: string
-) => void
+export type ImageDescribeCallback = NonNullable<ImageDescribeProps['onLoad']>
 
+/**
+ * Props specific to generating an image.
+ * @extends `Omit<NextImageProps, 'src' | 'width' | 'height' | 'alt' | 'onLoad' | 'onError' | 'quality'>`.
+ * @see `next/image` for full `NextImageProps` type information.
+ * @extends `Partial<Omit<OpenAI.ImageGenerateParams, 'n' | 'quality' | 'style'>>`.
+ * @see `openai` for full `ImageGenerateParams` type information.
+ */
 export interface ImageGenerateProps
 	extends Omit<
 			NextImageProps,
 			'src' | 'width' | 'height' | 'alt' | 'onLoad' | 'onError' | 'quality'
 		>,
-		Omit<ImageGenerationOptions, 'quality' | 'style'> {
+		Partial<Omit<OpenAI.ImageGenerateParams, 'n' | 'quality' | 'style'>> {
 	/**
-	 * Whether or not to render the result string adjacent to the image
+	 * Shows the image generation result base64 string or URL adjacent to the image.
 	 */
 	showResult?: boolean
-	/** Alternative text describing the image, uses `prompt` if not provided */
+	/** Alternative text describing the image, uses `prompt` if not provided. */
 	alt?: string
 	/**
 	 * The quality of the image that will be generated. `hd` creates images with finer
@@ -62,20 +79,35 @@ export interface ImageGenerateProps
 	imageStyle?: 'vivid' | 'natural' | null
 	/**
 	 * Callback function invoked once the image is completely loaded and the `placeholder` has been removed.
-	 * Returns the `event`, generation result `response` and the original `prompt`
 	 */
-	onLoad?: ImageGenerateCallback
-	/** Callback function that is invoked if the image fails to load. */
-	onError?: ImageGenerateCallback
+	onLoad?: (
+		/** A React `HTMLImageElement` event object with no additional properties. */
+		event: SyntheticEvent<HTMLImageElement, Event> | undefined,
+		/** Image generation response base64 string or URL. */
+		response?: ImageResponse<1> | undefined,
+		/**
+		 * A text description of the desired image. The maximum length is 1000
+		 * characters for `dall-e-2` and 4000 characters for `dall-e-3`.
+		 */
+		prompt?: string
+	) => void
+	/**
+	 * Callback function that is invoked if the image fails to load.
+	 */
+	onError?: (
+		/** A React `HTMLImageElement` event object with no additional properties. */
+		event: SyntheticEvent<HTMLImageElement, Event> | undefined,
+		/** Image generation response base64 string or URL. */
+		response?: ImageResponse<1> | undefined,
+		/**
+		 * A text description of the desired image. The maximum length is 1000
+		 * characters for `dall-e-2` and 4000 characters for `dall-e-3`.
+		 */
+		prompt?: string
+	) => void
 }
 
-export type ImageGenerateCallback = (
-	event: SyntheticEvent<HTMLImageElement, Event> | undefined,
-	/** Image generation response */
-	response?: ImageResponse<1>,
-	/** Image generation prompt */
-	prompt?: string
-) => void
+export type ImageGenerateCallback = NonNullable<ImageGenerateProps['onLoad']>
 
 export type ImageProps =
 	| ImageGenerateProps

--- a/packages/fullstack-components/src/types/Image.ts
+++ b/packages/fullstack-components/src/types/Image.ts
@@ -3,13 +3,17 @@ import { type ImageProps as NextImageProps } from 'next/image'
 import type { SyntheticEvent } from 'react'
 import type { ImageResponse } from '../handlers/image/models'
 
+type NextImageDescribeProps = Omit<
+	NextImageProps,
+	'src' | 'alt' | 'onLoad' | 'onError'
+>
+
 /**
- * Props specific to describing an image.
- * @extends `Omit<NextImageProps, 'src' | 'alt' | 'onLoad' | 'onError'>`
- * @see `next/image` for full `NextImageProps` type information.
+ * Props specific to describing an image. Used in `ImageProps`.
+ * @extends Omit<NextImageProps, 'src' | 'alt' | 'onLoad' | 'onError'>
+ * @link https://nextjs.org/docs/app/api-reference/components/image `next/image` for full `NextImageProps` type information.
  */
-export interface ImageDescribeProps
-	extends Omit<NextImageProps, 'src' | 'alt' | 'onLoad' | 'onError'> {
+export interface ImageDescribeProps extends NextImageDescribeProps {
 	/**
 	 * URL to the image to describe. Generates `alt` text.
 	 * The `alt` text is then passed to the image and returned in `onLoad`.
@@ -23,41 +27,56 @@ export interface ImageDescribeProps
 	 * Callback function invoked once the image is completely loaded and the `placeholder` has been removed.
 	 */
 	onLoad?: (
-		/** A React `HTMLImageElement` event object with no additional properties. */
+		/**
+		 * A React `HTMLImageElement` event object with no additional properties.
+		 */
 		event: SyntheticEvent<HTMLImageElement, Event> | undefined,
-		/** A text description response of the image. */
+		/**
+		 * A text description response of the image.
+		 */
 		response?: ImageResponse<1> | undefined,
-		/** Source of the image being described. */
+		/**
+		 * An absolute URL to the image being described.
+		 * @example 'https://absolute-cat-url/tabbycat.jpg'
+		 */
 		src?: string
 	) => void
 	/**
 	 * Callback function that is invoked if the image fails to load.
 	 */
 	onError?: (
-		/** A React `HTMLImageElement` event object with no additional properties. */
+		/**
+		 * A React `HTMLImageElement` event object with no additional properties.
+		 */
 		event: SyntheticEvent<HTMLImageElement, Event> | undefined,
-		/** A text description response of the image. */
+		/**
+		 * A text description response of the image.
+		 */
 		response?: ImageResponse<1> | undefined,
-		/** Source of the image being described. */
+		/**
+		 * An absolute URL to the image being described.
+		 * @example 'https://absolute-cat-url/tabbycat.jpg'
+		 */
 		src?: string
 	) => void
 }
 
 export type ImageDescribeCallback = NonNullable<ImageDescribeProps['onLoad']>
 
+type NextImageGenerateProps = Omit<
+	NextImageProps,
+	'src' | 'width' | 'height' | 'alt' | 'onLoad' | 'onError' | 'quality'
+> &
+	Partial<Omit<OpenAI.ImageGenerateParams, 'n' | 'quality' | 'style'>>
+
 /**
- * Props specific to generating an image.
- * @extends `Omit<NextImageProps, 'src' | 'width' | 'height' | 'alt' | 'onLoad' | 'onError' | 'quality'>`.
- * @see `next/image` for full `NextImageProps` type information.
- * @extends `Partial<Omit<OpenAI.ImageGenerateParams, 'n' | 'quality' | 'style'>>`.
- * @see `openai` for full `ImageGenerateParams` type information.
+ * Props specific to generating an image. Used in `ImageProps`.
+ * @extends NextImageProps
+ * @link https://nextjs.org/docs/app/api-reference/components/image `next/image` for full `NextImageProps` type information.
+ * @extends OpenAI.ImageGenerateParams
+ * @link https://www.npmjs.com/package/openai `openai` for full `ImageGenerateParams` type information.
  */
-export interface ImageGenerateProps
-	extends Omit<
-			NextImageProps,
-			'src' | 'width' | 'height' | 'alt' | 'onLoad' | 'onError' | 'quality'
-		>,
-		Partial<Omit<OpenAI.ImageGenerateParams, 'n' | 'quality' | 'style'>> {
+export interface ImageGenerateProps extends NextImageGenerateProps {
 	/**
 	 * Shows the image generation result base64 string or URL adjacent to the image.
 	 */
@@ -81,9 +100,13 @@ export interface ImageGenerateProps
 	 * Callback function invoked once the image is completely loaded and the `placeholder` has been removed.
 	 */
 	onLoad?: (
-		/** A React `HTMLImageElement` event object with no additional properties. */
+		/**
+		 * A React `HTMLImageElement` event object with no additional properties.
+		 */
 		event: SyntheticEvent<HTMLImageElement, Event> | undefined,
-		/** Image generation response base64 string or URL. */
+		/**
+		 * The image generation response as a base64 string or URL.
+		 */
 		response?: ImageResponse<1> | undefined,
 		/**
 		 * A text description of the desired image. The maximum length is 1000
@@ -95,9 +118,13 @@ export interface ImageGenerateProps
 	 * Callback function that is invoked if the image fails to load.
 	 */
 	onError?: (
-		/** A React `HTMLImageElement` event object with no additional properties. */
+		/**
+		 * A React `HTMLImageElement` event object with no additional properties.
+		 */
 		event: SyntheticEvent<HTMLImageElement, Event> | undefined,
-		/** Image generation response base64 string or URL. */
+		/**
+		 * The image generation response as a base64 string or URL.
+		 */
 		response?: ImageResponse<1> | undefined,
 		/**
 		 * A text description of the desired image. The maximum length is 1000
@@ -109,6 +136,9 @@ export interface ImageGenerateProps
 
 export type ImageGenerateCallback = NonNullable<ImageGenerateProps['onLoad']>
 
+/**
+ * Props to pass to the `<Image>` Server Component.
+ */
 export type ImageProps =
 	| ImageGenerateProps
 	| ImageDescribeProps

--- a/packages/fullstack-components/src/types/request.ts
+++ b/packages/fullstack-components/src/types/request.ts
@@ -1,7 +1,22 @@
+/**
+ * Fetch utility request options.
+ * @extends RequestInit fetch options
+ */
 export interface RequestConfig<TBody = unknown>
 	extends Omit<RequestInit, 'body'> {
+	/**
+	 * The base URL to use for the request.
+	 */
 	baseUrl?: string
+	/**
+	 * The fetch request body.
+	 */
 	body?: TBody
 }
 
+/**
+ * Fetch utility request options without the body.
+ * @link RequestConfig
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+ */
 export type RequestConfigOnly = Omit<RequestConfig, 'body'>

--- a/packages/fullstack-components/src/utils/renderToStaticMarkup.ts
+++ b/packages/fullstack-components/src/utils/renderToStaticMarkup.ts
@@ -2,7 +2,7 @@ import type { ReactElement, ReactNode } from 'react'
 
 /**
  * Renders a React tree to a static HTML string.
- * @see {@link https://github.com/vercel/next.js/issues/43810}
+ * @link https://github.com/vercel/next.js/issues/43810
  * @note server version of `client/renderToString`
  */
 export const renderToStaticMarkup = async (

--- a/packages/fullstack-components/src/utils/renderToStaticMarkup.ts
+++ b/packages/fullstack-components/src/utils/renderToStaticMarkup.ts
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode } from 'react'
 
 /**
- * Renders a react tree to a static HTML string.
+ * Renders a React tree to a static HTML string.
  * @see {@link https://github.com/vercel/next.js/issues/43810}
  * @note server version of `client/renderToString`
  */

--- a/packages/fullstack-components/src/utils/request.ts
+++ b/packages/fullstack-components/src/utils/request.ts
@@ -2,10 +2,19 @@ import { URL_HOST } from './constants'
 import type { RequestConfig } from '../types'
 export type { RequestConfig, RequestConfigOnly } from '../types'
 
+/**
+ * Fetch utility for calling internal Next.js API route handlers.
+ * Destructures the `body` from the `RequestConfig` and stringifies it.
+ */
 export const request = async <TResponse = unknown, Tbody = unknown>(
-	/** Relative API url */
+	/**
+	 * Relative API url
+	 */
 	url: string,
-	/** Fetch request config initialiser in addition to the `baseUrl` */
+	/**
+	 * Fetch request config initialiser in addition to the `baseUrl`
+	 * @link RequestConfig
+	 */
 	config?: RequestConfig<Tbody>
 ): Promise<TResponse> => {
 	const {

--- a/packages/fullstack-components/src/utils/styles.ts
+++ b/packages/fullstack-components/src/utils/styles.ts
@@ -2,7 +2,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
 /**
- * merge Tailwind CSS classes in JS without style conflicts.
+ * Merge Tailwind CSS classes in JS without style conflicts.
  * uses `clsx` first to parse inputs as it's more robust at handling various inputs.
  *
  * @see https://www.npmjs.com/package/tailwind-merge

--- a/packages/fullstack-components/src/utils/styles.ts
+++ b/packages/fullstack-components/src/utils/styles.ts
@@ -5,8 +5,8 @@ import { twMerge } from 'tailwind-merge'
  * Merge Tailwind CSS classes in JS without style conflicts.
  * uses `clsx` first to parse inputs as it's more robust at handling various inputs.
  *
- * @see https://www.npmjs.com/package/tailwind-merge
- * @see https://www.npmjs.com/package/clsx
+ * @link https://www.npmjs.com/package/tailwind-merge `tailwind-merge` for full `twMerge` type information.
+ * @link https://www.npmjs.com/package/clsx `clsx` for full `clsx` type information.
  */
 export function merge(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs))

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -35,12 +35,8 @@
 		"rehype-autolink-headings": "7.0.0",
 		"rehype-pretty-code": "0.11.0",
 		"rehype-slug": "6.0.0",
-		"rehype-stringify": "10.0.0",
 		"remark-gfm": "4.0.0",
-		"remark-parse": "11.0.0",
-		"remark-rehype": "11.0.0",
 		"shiki": "0.14.5",
-		"unified": "11.0.4",
 		"unist-util-visit": "5.0.0"
 	},
 	"devDependencies": {

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -22,6 +22,7 @@
 		"@twind/preset-autoprefix": "1.0.7",
 		"@twind/preset-tailwind": "1.1.4",
 		"@vercel/analytics": "1.1.1",
+		"@wix/typescript-schema-extract": "1.0.3",
 		"ai": "2.2.20",
 		"jsonrepair": "3.4.0",
 		"next": "14.0.1",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -34,8 +34,12 @@
 		"rehype-autolink-headings": "7.0.0",
 		"rehype-pretty-code": "0.11.0",
 		"rehype-slug": "6.0.0",
+		"rehype-stringify": "10.0.0",
 		"remark-gfm": "4.0.0",
+		"remark-parse": "11.0.0",
+		"remark-rehype": "11.0.0",
 		"shiki": "0.14.5",
+		"unified": "11.0.4",
 		"unist-util-visit": "5.0.0"
 	},
 	"devDependencies": {

--- a/packages/site/src/app/docs/block/page.mdx
+++ b/packages/site/src/app/docs/block/page.mdx
@@ -1,3 +1,4 @@
+import { TypesToMdx } from '@/src/components/TypesToMdx'
 import { Example } from '@/src/components/Example'
 import Blocks from './Blocks'
 import { URL_HOST } from '@/src/utils/constants'
@@ -95,3 +96,33 @@ const fscHandler = handleFSComponents(fscOptions)
 
 export { fscHandler as GET, fscHandler as POST }
 ```
+
+## API Reference
+
+<TypesToMdx
+  path="handlers/block/models.d.ts"
+  name="BlockOptions"
+  description="Block API handler route options."
+/>
+
+<TypesToMdx
+  path="handlers/block/models.d.ts"
+  name="BlockRequestBody"
+  description="Block request body."
+/>
+
+<TypesToMdx path="components/Block.d.ts" name="BlockProps" />
+
+<TypesToMdx path="components/Block.d.ts" name="Block" />
+
+<TypesToMdx path="handlers/block/useBlock.d.ts" name="useBlock" />
+
+<TypesToMdx
+  path="handlers/block/blockClient.d.ts"
+  name="getBlock"
+/>
+
+<TypesToMdx
+  path="handlers/block/fetchers.d.ts"
+  name="fetchBlock"
+/>

--- a/packages/site/src/app/docs/block/page.mdx
+++ b/packages/site/src/app/docs/block/page.mdx
@@ -1,4 +1,4 @@
-import { TypesToMdx } from '@/src/components/TypesToMdx'
+import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
 import { Example } from '@/src/components/Example'
 import Blocks from './Blocks'
 import { URL_HOST } from '@/src/utils/constants'
@@ -99,30 +99,33 @@ export { fscHandler as GET, fscHandler as POST }
 
 ## API Reference
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/block/models.d.ts"
   name="BlockOptions"
   description="Block API handler route options."
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/block/models.d.ts"
   name="BlockRequestBody"
   description="Block request body."
 />
 
-<TypesToMdx path="components/Block.d.ts" name="BlockProps" />
+<TypeInfoToText path="components/Block.d.ts" name="BlockProps" />
 
-<TypesToMdx path="components/Block.d.ts" name="Block" />
+<TypeInfoToText path="components/Block.d.ts" name="Block" />
 
-<TypesToMdx path="handlers/block/useBlock.d.ts" name="useBlock" />
+<TypeInfoToText
+  path="handlers/block/useBlock.d.ts"
+  name="useBlock"
+/>
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/block/blockClient.d.ts"
   name="getBlock"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/block/fetchers.d.ts"
   name="fetchBlock"
 />

--- a/packages/site/src/app/docs/error-enhancer/page.mdx
+++ b/packages/site/src/app/docs/error-enhancer/page.mdx
@@ -1,3 +1,4 @@
+import { TypesToMdx } from '@/src/components/TypesToMdx'
 import { ErrorHTTPPreview } from './ErrorHTTPPreview'
 import { ClientErrors } from './ClientErrors'
 import { URL_HOST } from '@/src/utils/constants'
@@ -153,3 +154,53 @@ const fscHandler = handleFSComponents(fscOptions)
 
 export { fscHandler as GET, fscHandler as POST }
 ```
+
+## API Reference
+
+<TypesToMdx
+  path="handlers/errorEnhancer/models.d.ts"
+  name="ErrorParserOptions"
+  description="Error enhancer API handler route options."
+/>
+
+<TypesToMdx
+  path="handlers/errorEnhancer/models.d.ts"
+  name="ErrorEnhancementRequestBody"
+  description="Error enhancer request body."
+/>
+
+<TypesToMdx
+  path="handlers/errorEnhancer/models.d.ts"
+  name="ErrorEnhancementResponse"
+  description="Error enhancer response body."
+/>
+
+<TypesToMdx
+  path="components/ErrorEnhancementBoundary.d.ts"
+  name="ErrorEnhancementBoundary"
+/>
+
+<TypesToMdx
+  path="components/ErrorEnhancementFallback.d.ts"
+  name="ErrorEnhancementFallbackProps"
+/>
+
+<TypesToMdx
+  path="components/ErrorEnhancementFallback.d.ts"
+  name="ErrorEnhancementFallback"
+/>
+
+<TypesToMdx
+  path="handlers/errorEnhancer/useErrorEnhancement.d.ts"
+  name="useErrorEnhancement"
+/>
+
+<TypesToMdx
+  path="handlers/errorEnhancer/errorClient.d.ts"
+  name="getErrorEnhancement"
+/>
+
+<TypesToMdx
+  path="handlers/errorEnhancer/fetchers.d.ts"
+  name="fetchErrorEnhancement"
+/>

--- a/packages/site/src/app/docs/error-enhancer/page.mdx
+++ b/packages/site/src/app/docs/error-enhancer/page.mdx
@@ -1,4 +1,4 @@
-import { TypesToMdx } from '@/src/components/TypesToMdx'
+import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
 import { ErrorHTTPPreview } from './ErrorHTTPPreview'
 import { ClientErrors } from './ClientErrors'
 import { URL_HOST } from '@/src/utils/constants'
@@ -157,50 +157,50 @@ export { fscHandler as GET, fscHandler as POST }
 
 ## API Reference
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/errorEnhancer/models.d.ts"
   name="ErrorParserOptions"
   description="Error enhancer API handler route options."
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/errorEnhancer/models.d.ts"
   name="ErrorEnhancementRequestBody"
   description="Error enhancer request body."
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/errorEnhancer/models.d.ts"
   name="ErrorEnhancementResponse"
   description="Error enhancer response body."
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="components/ErrorEnhancementBoundary.d.ts"
   name="ErrorEnhancementBoundary"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="components/ErrorEnhancementFallback.d.ts"
   name="ErrorEnhancementFallbackProps"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="components/ErrorEnhancementFallback.d.ts"
   name="ErrorEnhancementFallback"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/errorEnhancer/useErrorEnhancement.d.ts"
   name="useErrorEnhancement"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/errorEnhancer/errorClient.d.ts"
   name="getErrorEnhancement"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/errorEnhancer/fetchers.d.ts"
   name="fetchErrorEnhancement"
 />

--- a/packages/site/src/app/docs/html-page-generator/page.mdx
+++ b/packages/site/src/app/docs/html-page-generator/page.mdx
@@ -1,4 +1,4 @@
-import { TypesToMdx } from '@/src/components/TypesToMdx'
+import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
 import { Form } from './Form'
 import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
@@ -129,29 +129,29 @@ export { fscHandler as GET, fscHandler as POST }
 
 ## API Reference
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/htmlPage/models.d.ts"
   name="HtmlPageOptions"
   description="HTML page generator API handler route options."
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/htmlPage/models.d.ts"
   name="HtmlPageRequestBody"
   description="HTML page generator request body."
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/htmlPage/useHtmlPage.d.ts"
   name="useHtmlPage"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/htmlPage/htmlPageClient.d.ts"
   name="getHtmlPage"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/htmlPage/fetchers.d.ts"
   name="fetchHtmlPage"
 />

--- a/packages/site/src/app/docs/html-page-generator/page.mdx
+++ b/packages/site/src/app/docs/html-page-generator/page.mdx
@@ -1,3 +1,4 @@
+import { TypesToMdx } from '@/src/components/TypesToMdx'
 import { Form } from './Form'
 import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
@@ -125,3 +126,32 @@ const fscHandler = handleFSComponents(fscOptions)
 
 export { fscHandler as GET, fscHandler as POST }
 ```
+
+## API Reference
+
+<TypesToMdx
+  path="handlers/htmlPage/models.d.ts"
+  name="HtmlPageOptions"
+  description="HTML page generator API handler route options."
+/>
+
+<TypesToMdx
+  path="handlers/htmlPage/models.d.ts"
+  name="HtmlPageRequestBody"
+  description="HTML page generator request body."
+/>
+
+<TypesToMdx
+  path="handlers/htmlPage/useHtmlPage.d.ts"
+  name="useHtmlPage"
+/>
+
+<TypesToMdx
+  path="handlers/htmlPage/htmlPageClient.d.ts"
+  name="getHtmlPage"
+/>
+
+<TypesToMdx
+  path="handlers/htmlPage/fetchers.d.ts"
+  name="fetchHtmlPage"
+/>

--- a/packages/site/src/app/docs/image/Image.tsx
+++ b/packages/site/src/app/docs/image/Image.tsx
@@ -1,0 +1,21 @@
+/* eslint-disable jsx-a11y/alt-text */
+import { Image } from '@trikinco/fullstack-components'
+
+export default async function Page() {
+	return (
+		<div>
+			{/* Describing an image */}
+			<Image
+				src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Felis_catus-cat_on_snow.jpg/179px-Felis_catus-cat_on_snow.jpg"
+				width={256}
+				height={170}
+			/>
+			{/* Generating an image */}
+			<Image
+				prompt="A photograph of a cat wearing a cowboy hat"
+				model="dall-e-3"
+				size="1024x1024"
+			/>
+		</div>
+	)
+}

--- a/packages/site/src/app/docs/image/page.mdx
+++ b/packages/site/src/app/docs/image/page.mdx
@@ -1,3 +1,4 @@
+import { TypesToMdx } from '@/src/components/TypesToMdx'
 import { Image } from '@trikinco/fullstack-components'
 import { Example } from '@/src/components/Example'
 import { URL_HOST } from '@/src/utils/constants'
@@ -40,7 +41,7 @@ import { useImage } from '@trikinco/fullstack-components/client'
 
 ```jsx
 <Image
-  src="https://absolute-cat-url.jpg"
+  src="https://absolute-cat-url/tabbycat.jpg"
   showResult // Optional - to render the alt-text visually
   width={256}
   height={170}
@@ -214,3 +215,45 @@ const fscHandler = handleFSComponents(fscOptions)
 
 export { fscHandler as GET, fscHandler as POST }
 ```
+
+## API Reference
+
+<TypesToMdx
+  path="handlers/image/models.d.ts"
+  name="ImageOptions"
+  description="Image API handler route options."
+/>
+
+<TypesToMdx
+  path="handlers/image/models.d.ts"
+  name="ImageRequestBody"
+/>
+
+<TypesToMdx
+  path="types/Image.d.ts"
+  name="ImageProps"
+  description="Props to pass to the `<Image>` Server Component."
+/>
+
+<TypesToMdx path="types/Image.d.ts" name="ImageGenerateProps" />
+
+<TypesToMdx path="types/Image.d.ts" name="ImageDescribeProps" />
+
+<TypesToMdx path="components/Image/Image.d.ts" name="Image" />
+
+<TypesToMdx path="handlers/image/useImage.d.ts" name="useImage" />
+
+<TypesToMdx
+  path="handlers/image/imageClient.d.ts"
+  name="getImage"
+/>
+
+<TypesToMdx
+  path="handlers/image/getters.d.ts"
+  name="getEnhancedImage"
+/>
+
+<TypesToMdx
+  path="handlers/image/fetchers.d.ts"
+  name="fetchImage"
+/>

--- a/packages/site/src/app/docs/image/page.mdx
+++ b/packages/site/src/app/docs/image/page.mdx
@@ -1,4 +1,4 @@
-import { TypesToMdx } from '@/src/components/TypesToMdx'
+import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
 import { Image } from '@trikinco/fullstack-components'
 import { Example } from '@/src/components/Example'
 import { URL_HOST } from '@/src/utils/constants'
@@ -218,42 +218,51 @@ export { fscHandler as GET, fscHandler as POST }
 
 ## API Reference
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/image/models.d.ts"
   name="ImageOptions"
   description="Image API handler route options."
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/image/models.d.ts"
   name="ImageRequestBody"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="types/Image.d.ts"
   name="ImageProps"
   description="Props to pass to the `<Image>` Server Component."
 />
 
-<TypesToMdx path="types/Image.d.ts" name="ImageGenerateProps" />
+<TypeInfoToText
+  path="types/Image.d.ts"
+  name="ImageGenerateProps"
+/>
 
-<TypesToMdx path="types/Image.d.ts" name="ImageDescribeProps" />
+<TypeInfoToText
+  path="types/Image.d.ts"
+  name="ImageDescribeProps"
+/>
 
-<TypesToMdx path="components/Image/Image.d.ts" name="Image" />
+<TypeInfoToText path="components/Image/Image.d.ts" name="Image" />
 
-<TypesToMdx path="handlers/image/useImage.d.ts" name="useImage" />
+<TypeInfoToText
+  path="handlers/image/useImage.d.ts"
+  name="useImage"
+/>
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/image/imageClient.d.ts"
   name="getImage"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/image/getters.d.ts"
   name="getEnhancedImage"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/image/fetchers.d.ts"
   name="fetchImage"
 />

--- a/packages/site/src/app/docs/not-found-enhancer/page.mdx
+++ b/packages/site/src/app/docs/not-found-enhancer/page.mdx
@@ -1,3 +1,4 @@
+import { TypesToMdx } from '@/src/components/TypesToMdx'
 import { Example } from '@/src/components/Example'
 import { NotFoundEnhancer } from './NotFoundEnhancer'
 import { URL_HOST } from '@/src/utils/constants'
@@ -129,3 +130,43 @@ export default function NotFound() {
   )
 }
 ```
+
+## API Reference
+
+<TypesToMdx
+  path="handlers/notFoundEnhancer/models.d.ts"
+  name="NotFoundEnhancerOptions"
+  description="Not found enhancer API handler route options."
+/>
+
+<TypesToMdx
+  path="handlers/notFoundEnhancer/models.d.ts"
+  name="NotFoundEnhancerRequestBody"
+  description="Not found enhancer request body."
+/>
+
+<TypesToMdx
+  path="handlers/notFoundEnhancer/models.d.ts"
+  name="NotFoundEnhancerResponse"
+  description="Not found enhancer response body."
+/>
+
+<TypesToMdx
+  path="handlers/notFoundEnhancer/useNotFoundEnhancement.d.ts"
+  name="useNotFoundEnhancement"
+/>
+
+<TypesToMdx
+  path="handlers/notFoundEnhancer/notFoundEnhancerContentGenerator.d.ts"
+  name="getNotFoundContentGenerator"
+/>
+
+<TypesToMdx
+  path="handlers/notFoundEnhancer/notFoundEnhancerSitemapSelector.d.ts"
+  name="getNotFoundSitemapSelector"
+/>
+
+<TypesToMdx
+  path="handlers/notFoundEnhancer/fetchers.d.ts"
+  name="fetchNotFoundEnhancement"
+/>

--- a/packages/site/src/app/docs/not-found-enhancer/page.mdx
+++ b/packages/site/src/app/docs/not-found-enhancer/page.mdx
@@ -1,4 +1,4 @@
-import { TypesToMdx } from '@/src/components/TypesToMdx'
+import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
 import { Example } from '@/src/components/Example'
 import { NotFoundEnhancer } from './NotFoundEnhancer'
 import { URL_HOST } from '@/src/utils/constants'
@@ -133,40 +133,40 @@ export default function NotFound() {
 
 ## API Reference
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/notFoundEnhancer/models.d.ts"
   name="NotFoundEnhancerOptions"
   description="Not found enhancer API handler route options."
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/notFoundEnhancer/models.d.ts"
   name="NotFoundEnhancerRequestBody"
   description="Not found enhancer request body."
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/notFoundEnhancer/models.d.ts"
   name="NotFoundEnhancerResponse"
   description="Not found enhancer response body."
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/notFoundEnhancer/useNotFoundEnhancement.d.ts"
   name="useNotFoundEnhancement"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/notFoundEnhancer/notFoundEnhancerContentGenerator.d.ts"
   name="getNotFoundContentGenerator"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/notFoundEnhancer/notFoundEnhancerSitemapSelector.d.ts"
   name="getNotFoundSitemapSelector"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/notFoundEnhancer/fetchers.d.ts"
   name="fetchNotFoundEnhancement"
 />

--- a/packages/site/src/app/docs/prompt/Prompts.tsx
+++ b/packages/site/src/app/docs/prompt/Prompts.tsx
@@ -1,0 +1,22 @@
+import { Prompt } from '@trikinco/fullstack-components'
+
+export default async function Page() {
+	return (
+		<div>
+			<Prompt prompt="What is TailwindCSS?" />
+			<Prompt
+				messages={[
+					{
+						role: 'system',
+						content:
+							'You translate Norwegian to English. You return the translated text directly',
+					},
+					{
+						role: 'user',
+						content: 'Reven rasker over isen',
+					},
+				]}
+			/>
+		</div>
+	)
+}

--- a/packages/site/src/app/docs/prompt/page.mdx
+++ b/packages/site/src/app/docs/prompt/page.mdx
@@ -1,4 +1,4 @@
-import { TypesToMdx } from '@/src/components/TypesToMdx'
+import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
 import { Prompt } from '@trikinco/fullstack-components'
 import { Example } from '@/src/components/Example'
 import { URL_HOST } from '@/src/utils/constants'
@@ -161,33 +161,36 @@ export { fscHandler as GET, fscHandler as POST }
 
 ## API Reference
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/prompt/models.d.ts"
   name="PromptOptions"
   description="Prompt API handler route options."
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/prompt/models.d.ts"
   name="PromptRequestBody"
   description="Prompt request body."
 />
 
-<TypesToMdx path="components/Prompt.d.ts" name="PromptProps" />
+<TypeInfoToText
+  path="components/Prompt.d.ts"
+  name="PromptProps"
+/>
 
-<TypesToMdx path="components/Prompt.d.ts" name="Prompt" />
+<TypeInfoToText path="components/Prompt.d.ts" name="Prompt" />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/prompt/usePrompt.d.ts"
   name="usePrompt"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/prompt/promptClient.d.ts"
   name="getPrompt"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/prompt/fetchers.d.ts"
   name="fetchPrompt"
 />

--- a/packages/site/src/app/docs/prompt/page.mdx
+++ b/packages/site/src/app/docs/prompt/page.mdx
@@ -1,3 +1,4 @@
+import { TypesToMdx } from '@/src/components/TypesToMdx'
 import { Prompt } from '@trikinco/fullstack-components'
 import { Example } from '@/src/components/Example'
 import { URL_HOST } from '@/src/utils/constants'
@@ -157,3 +158,36 @@ const fscHandler = handleFSComponents(fscOptions)
 
 export { fscHandler as GET, fscHandler as POST }
 ```
+
+## API Reference
+
+<TypesToMdx
+  path="handlers/prompt/models.d.ts"
+  name="PromptOptions"
+  description="Prompt API handler route options."
+/>
+
+<TypesToMdx
+  path="handlers/prompt/models.d.ts"
+  name="PromptRequestBody"
+  description="Prompt request body."
+/>
+
+<TypesToMdx path="components/Prompt.d.ts" name="PromptProps" />
+
+<TypesToMdx path="components/Prompt.d.ts" name="Prompt" />
+
+<TypesToMdx
+  path="handlers/prompt/usePrompt.d.ts"
+  name="usePrompt"
+/>
+
+<TypesToMdx
+  path="handlers/prompt/promptClient.d.ts"
+  name="getPrompt"
+/>
+
+<TypesToMdx
+  path="handlers/prompt/fetchers.d.ts"
+  name="fetchPrompt"
+/>

--- a/packages/site/src/app/docs/select/page.mdx
+++ b/packages/site/src/app/docs/select/page.mdx
@@ -1,4 +1,4 @@
-import { TypesToMdx } from '@/src/components/TypesToMdx'
+import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
 import { Select } from '@trikinco/fullstack-components'
 import { Example } from '@/src/components/Example'
 import UseSelect from './UseSelect'
@@ -162,33 +162,36 @@ import { useSelect } from '@trikinco/fullstack-components/client'
 
 ## API Reference
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/select/models.d.ts"
   name="SelectOptions"
   description="Select API handler route options."
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/select/models.d.ts"
   name="SelectRequestBody"
   description="Select request body."
 />
 
-<TypesToMdx path="components/Select.d.ts" name="SelectProps" />
+<TypeInfoToText
+  path="components/Select.d.ts"
+  name="SelectProps"
+/>
 
-<TypesToMdx path="components/Select.d.ts" name="Select" />
+<TypeInfoToText path="components/Select.d.ts" name="Select" />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/select/useSelect.d.ts"
   name="useSelect"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/select/selectClient.d.ts"
   name="getSelect"
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/select/fetchers.d.ts"
   name="fetchSelect"
 />

--- a/packages/site/src/app/docs/select/page.mdx
+++ b/packages/site/src/app/docs/select/page.mdx
@@ -1,3 +1,4 @@
+import { TypesToMdx } from '@/src/components/TypesToMdx'
 import { Select } from '@trikinco/fullstack-components'
 import { Example } from '@/src/components/Example'
 import UseSelect from './UseSelect'
@@ -158,3 +159,36 @@ export { fscHandler as GET, fscHandler as POST }
 import { Select } from '@trikinco/fullstack-components'
 import { useSelect } from '@trikinco/fullstack-components/client'
 ```
+
+## API Reference
+
+<TypesToMdx
+  path="handlers/select/models.d.ts"
+  name="SelectOptions"
+  description="Select API handler route options."
+/>
+
+<TypesToMdx
+  path="handlers/select/models.d.ts"
+  name="SelectRequestBody"
+  description="Select request body."
+/>
+
+<TypesToMdx path="components/Select.d.ts" name="SelectProps" />
+
+<TypesToMdx path="components/Select.d.ts" name="Select" />
+
+<TypesToMdx
+  path="handlers/select/useSelect.d.ts"
+  name="useSelect"
+/>
+
+<TypesToMdx
+  path="handlers/select/selectClient.d.ts"
+  name="getSelect"
+/>
+
+<TypesToMdx
+  path="handlers/select/fetchers.d.ts"
+  name="fetchSelect"
+/>

--- a/packages/site/src/app/docs/text/page.mdx
+++ b/packages/site/src/app/docs/text/page.mdx
@@ -1,4 +1,4 @@
-import { TypesToMdx } from '@/src/components/TypesToMdx'
+import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
 import { Text } from '@trikinco/fullstack-components'
 import { Example } from '@/src/components/Example'
 import { URL_HOST } from '@/src/utils/constants'
@@ -213,24 +213,33 @@ export { fscHandler as GET, fscHandler as POST }
 
 ## API Reference
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/text/models.d.ts"
   name="TextOptions"
   description="Text API handler route options."
 />
 
-<TypesToMdx
+<TypeInfoToText
   path="handlers/text/models.d.ts"
   name="TextRequestBody"
   description="Text request body."
 />
 
-<TypesToMdx path="components/Text.d.ts" name="TextProps" />
+<TypeInfoToText path="components/Text.d.ts" name="TextProps" />
 
-<TypesToMdx path="components/Text.d.ts" name="Text" />
+<TypeInfoToText path="components/Text.d.ts" name="Text" />
 
-<TypesToMdx path="handlers/text/useText.d.ts" name="useText" />
+<TypeInfoToText
+  path="handlers/text/useText.d.ts"
+  name="useText"
+/>
 
-<TypesToMdx path="handlers/text/textClient.d.ts" name="getText" />
+<TypeInfoToText
+  path="handlers/text/textClient.d.ts"
+  name="getText"
+/>
 
-<TypesToMdx path="handlers/text/fetchers.d.ts" name="fetchText" />
+<TypeInfoToText
+  path="handlers/text/fetchers.d.ts"
+  name="fetchText"
+/>

--- a/packages/site/src/app/docs/text/page.mdx
+++ b/packages/site/src/app/docs/text/page.mdx
@@ -1,3 +1,4 @@
+import { TypesToMdx } from '@/src/components/TypesToMdx'
 import { Text } from '@trikinco/fullstack-components'
 import { Example } from '@/src/components/Example'
 import { URL_HOST } from '@/src/utils/constants'
@@ -209,3 +210,27 @@ const fscHandler = handleFSComponents(fscOptions)
 
 export { fscHandler as GET, fscHandler as POST }
 ```
+
+## API Reference
+
+<TypesToMdx
+  path="handlers/text/models.d.ts"
+  name="TextOptions"
+  description="Text API handler route options."
+/>
+
+<TypesToMdx
+  path="handlers/text/models.d.ts"
+  name="TextRequestBody"
+  description="Text request body."
+/>
+
+<TypesToMdx path="components/Text.d.ts" name="TextProps" />
+
+<TypesToMdx path="components/Text.d.ts" name="Text" />
+
+<TypesToMdx path="handlers/text/useText.d.ts" name="useText" />
+
+<TypesToMdx path="handlers/text/textClient.d.ts" name="getText" />
+
+<TypesToMdx path="handlers/text/fetchers.d.ts" name="fetchText" />

--- a/packages/site/src/components/Accordion.tsx
+++ b/packages/site/src/components/Accordion.tsx
@@ -1,0 +1,69 @@
+import type {
+	DetailedHTMLProps,
+	DetailsHTMLAttributes,
+	HTMLAttributes,
+	ReactNode,
+} from 'react'
+import { merge } from '@trikinco/fullstack-components/utils'
+
+export interface AccordionProps
+	extends DetailedHTMLProps<
+		DetailsHTMLAttributes<HTMLDetailsElement>,
+		HTMLDetailsElement
+	> {
+	children?: ReactNode
+	/**
+	 * Summary label text
+	 */
+	label: ReactNode
+	/**
+	 * Additional props to pass to the summary `<summary>`.
+	 */
+	summaryProps?: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>
+	/**
+	 * Additional props to pass to the content wrapper `<div>`.
+	 */
+	contentProps?: DetailedHTMLProps<
+		HTMLAttributes<HTMLDivElement>,
+		HTMLDivElement
+	>
+}
+
+/**
+ * A simple accordion component.
+ */
+export const Accordion = ({
+	label,
+	children,
+	className,
+	summaryProps,
+	contentProps,
+	...rest
+}: AccordionProps) => {
+	const { className: summaryClassName, ...summaryRest } = summaryProps || {}
+	const { className: contentClassName, ...contentRest } = contentProps || {}
+
+	return (
+		<details {...rest}>
+			<summary
+				className={merge(
+					'[&::marker]:content-none [&::-webkit-details-marker]:hidden list-none appearance-none flex gap-2 mt-3 cursor-pointer text-sm text-slate-500 hover:text-black dark:hover:text-slate-600',
+					summaryClassName
+				)}
+				{...summaryRest}
+			>
+				{label}
+			</summary>
+
+			<div
+				className={merge(
+					'mt-3 border rounded-md border-slate-200 dark:border-slate-800',
+					contentClassName
+				)}
+				{...contentRest}
+			>
+				{children}
+			</div>
+		</details>
+	)
+}

--- a/packages/site/src/components/Accordion.tsx
+++ b/packages/site/src/components/Accordion.tsx
@@ -47,7 +47,7 @@ export const Accordion = ({
 		<details {...rest}>
 			<summary
 				className={merge(
-					'[&::marker]:content-none [&::-webkit-details-marker]:hidden list-none appearance-none flex gap-2 mt-3 cursor-pointer text-sm text-slate-500 hover:text-black dark:hover:text-slate-600',
+					'[&::marker]:content-none [&::-webkit-details-marker]:hidden list-none appearance-none flex gap-2 mt-3 cursor-pointer text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300',
 					summaryClassName
 				)}
 				{...summaryRest}

--- a/packages/site/src/components/Icons/IconMenuAlt.tsx
+++ b/packages/site/src/components/Icons/IconMenuAlt.tsx
@@ -1,0 +1,27 @@
+import type { SVGAttributes } from 'react'
+import { merge } from '@trikinco/fullstack-components/utils'
+
+/**
+ * https://www.svgrepo.com/collection/dazzle-line-icons/
+ */
+export const IconMenuAlt = ({
+	className,
+	...rest
+}: SVGAttributes<SVGSVGElement>) => (
+	<svg
+		viewBox="0 0 24 24"
+		xmlns="http://www.w3.org/2000/svg"
+		className={merge('w-5 h-5', className)}
+		fill="none"
+		aria-hidden="true"
+		{...rest}
+	>
+		<path
+			d="M4 6H20M4 12H14M4 18H9"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+	</svg>
+)

--- a/packages/site/src/components/TypeInfo.tsx
+++ b/packages/site/src/components/TypeInfo.tsx
@@ -1,23 +1,24 @@
-import type { HTMLAttributes, ReactNode } from 'react'
+import { type HTMLAttributes, type ReactNode, type ElementType } from 'react'
 import { merge } from '@trikinco/fullstack-components/utils'
 import { IconMenuAlt } from './Icons/IconMenuAlt'
+import { type ExtractedTypeInfo } from '../utils/getTypeDocs'
 
-export interface TypeInfoDetails {
+export interface TypeInfoDetails
+	extends Omit<
+		ExtractedTypeInfo,
+		'name' | 'description' | 'parameters' | 'properties'
+	> {
 	/**
 	 * Name of the type or interface to extract.
 	 * Needed to extract a single type from a .ts/x file
 	 * @example
 	 * 'ButtonProps'
 	 */
-	name: string
+	name: ReactNode
 	/**
-	 * The type name
+	 * Hides the `name`, `type` and `required` in the title
 	 */
-	type: string
-	/**
-	 * Whether the type is required or not
-	 */
-	required: boolean
+	hideName?: boolean
 	/**
 	 * Description to override the top level type description
 	 */
@@ -35,16 +36,24 @@ export interface TypeInfoProps
 	 * Parameters of complex types
 	 */
 	parameters?: TypeInfoDetails[]
+	/**
+	 * The title component type
+	 * @default 'p''
+	 */
+	component?: ElementType
 }
 
 export const TypeInfo = ({
 	name,
 	type,
 	required,
+	hideName,
 	description,
 	parameters,
 	children,
 	className,
+	tags,
+	component: TitleComponent = 'p',
 	...rest
 }: TypeInfoProps) => {
 	return (
@@ -55,21 +64,41 @@ export const TypeInfo = ({
 			)}
 			{...rest}
 		>
-			<p className="flex gap-2 m-0">
-				<span className="font-bold">{name}</span>
-				<span className="text-sm font-mono my-auto text-slate-500">{type}</span>
-				{required && (
-					<span className="text-sm font-mono my-auto text-red-600">
-						required
-					</span>
-				)}
-			</p>
-			{description && (
-				<span
-					className="whitespace-pre-wrap [&>*]:m-0"
-					dangerouslySetInnerHTML={{ __html: description }}
-				/>
+			{!hideName && (
+				<TitleComponent className="flex gap-2 m-0">
+					{name && <span className="font-bold">{name}</span>}
+					{type && (
+						<span className="text-sm font-mono my-auto text-slate-500">
+							{type}
+						</span>
+					)}
+					{required && (
+						<span className="text-sm font-mono my-auto text-red-600">
+							required
+						</span>
+					)}
+				</TitleComponent>
 			)}
+
+			{description && (
+				<span className="not-prose whitespace-pre-wrap [font-variant-ligatures:none] [&>*]:m-0">
+					{description}
+				</span>
+			)}
+
+			{tags && tags.length > 0 && (
+				<ul className="not-prose">
+					{tags.map(({ name, value }) => (
+						<li key={name}>
+							<span className="font-bold text-[--shiki-token-keyword] mr-2">
+								{name}
+							</span>
+							{value}
+						</li>
+					))}
+				</ul>
+			)}
+
 			{parameters && parameters.length > 0 && (
 				<details>
 					<summary className="[&::marker]:content-none flex gap-2 mt-3 cursor-pointer text-sm text-slate-500 hover:text-black dark:hover:text-slate-600">
@@ -77,9 +106,9 @@ export const TypeInfo = ({
 					</summary>
 
 					<div className="mt-3 border rounded-md border-slate-200 dark:border-slate-800">
-						{parameters.map((param) => (
+						{parameters.map((param, i) => (
 							<TypeInfo
-								key={param.name}
+								key={i}
 								className="p-6 first-of-type:border-t-0"
 								{...param}
 							/>

--- a/packages/site/src/components/TypeInfo.tsx
+++ b/packages/site/src/components/TypeInfo.tsx
@@ -1,0 +1,93 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+import { merge } from '@trikinco/fullstack-components/utils'
+import { IconMenuAlt } from './Icons/IconMenuAlt'
+
+export interface TypeInfoDetails {
+	/**
+	 * Name of the type or interface to extract.
+	 * Needed to extract a single type from a .ts/x file
+	 * @example
+	 * 'ButtonProps'
+	 */
+	name: string
+	/**
+	 * The type name
+	 */
+	type: string
+	/**
+	 * Whether the type is required or not
+	 */
+	required: boolean
+	/**
+	 * Description to override the top level type description
+	 */
+	description?: ReactNode
+}
+
+export interface TypeInfoProps
+	extends Omit<HTMLAttributes<HTMLDivElement>, 'title'>,
+		TypeInfoDetails {
+	/**
+	 * Children to show after the description
+	 */
+	children?: ReactNode
+	/**
+	 * Parameters of complex types
+	 */
+	parameters?: TypeInfoDetails[]
+}
+
+export const TypeInfo = ({
+	name,
+	type,
+	required,
+	description,
+	parameters,
+	children,
+	className,
+	...rest
+}: TypeInfoProps) => {
+	return (
+		<div
+			className={merge(
+				'flex flex-col gap-2 py-6 border-t border-slate-200 dark:border-slate-800',
+				className
+			)}
+			{...rest}
+		>
+			<p className="flex gap-2 m-0">
+				<span className="font-bold">{name}</span>
+				<span className="text-sm font-mono my-auto text-slate-500">{type}</span>
+				{required && (
+					<span className="text-sm font-mono my-auto text-red-600">
+						required
+					</span>
+				)}
+			</p>
+			{description && (
+				<span
+					className="whitespace-pre-wrap [&>*]:m-0"
+					dangerouslySetInnerHTML={{ __html: description }}
+				/>
+			)}
+			{parameters && parameters.length > 0 && (
+				<details>
+					<summary className="[&::marker]:content-none flex gap-2 mt-3 cursor-pointer text-sm text-slate-500 hover:text-black dark:hover:text-slate-600">
+						<IconMenuAlt width={20} height={20} /> Parameters
+					</summary>
+
+					<div className="mt-3 border rounded-md border-slate-200 dark:border-slate-800">
+						{parameters.map((param) => (
+							<TypeInfo
+								key={param.name}
+								className="p-6 first-of-type:border-t-0"
+								{...param}
+							/>
+						))}
+					</div>
+				</details>
+			)}
+			{children}
+		</div>
+	)
+}

--- a/packages/site/src/components/TypeInfo.tsx
+++ b/packages/site/src/components/TypeInfo.tsx
@@ -1,6 +1,7 @@
 import { type HTMLAttributes, type ReactNode, type ElementType } from 'react'
 import { merge } from '@trikinco/fullstack-components/utils'
 import { IconMenuAlt } from './Icons/IconMenuAlt'
+import { Accordion } from './Accordion'
 import { type ExtractedTypeInfo } from '../utils/getTypeDocs'
 
 export interface TypeInfoDetails
@@ -100,21 +101,21 @@ export const TypeInfo = ({
 			)}
 
 			{parameters && parameters.length > 0 && (
-				<details>
-					<summary className="[&::marker]:content-none flex gap-2 mt-3 cursor-pointer text-sm text-slate-500 hover:text-black dark:hover:text-slate-600">
-						<IconMenuAlt width={20} height={20} /> Parameters
-					</summary>
-
-					<div className="mt-3 border rounded-md border-slate-200 dark:border-slate-800">
-						{parameters.map((param, i) => (
-							<TypeInfo
-								key={i}
-								className="p-6 first-of-type:border-t-0"
-								{...param}
-							/>
-						))}
-					</div>
-				</details>
+				<Accordion
+					label={
+						<>
+							<IconMenuAlt width={20} height={20} /> Parameters
+						</>
+					}
+				>
+					{parameters.map((param, i) => (
+						<TypeInfo
+							key={i}
+							className="p-6 first-of-type:border-t-0"
+							{...param}
+						/>
+					))}
+				</Accordion>
 			)}
 			{children}
 		</div>

--- a/packages/site/src/components/TypeInfo/TypeInfo.tsx
+++ b/packages/site/src/components/TypeInfo/TypeInfo.tsx
@@ -74,12 +74,12 @@ export const TypeInfo = ({
 				<TitleComponent className="flex gap-2 m-0 scroll-mt-10" id={id}>
 					{name && <span className="font-bold">{name}</span>}
 					{type && (
-						<span className="text-sm font-mono my-auto text-slate-500">
+						<span className="text-sm font-mono font-normal my-auto text-slate-500 dark:text-slate-400">
 							{type}
 						</span>
 					)}
 					{required && (
-						<span className="text-sm font-mono my-auto text-red-600">
+						<span className="text-sm font-mono font-normal my-auto text-red-600">
 							required
 						</span>
 					)}

--- a/packages/site/src/components/TypeInfo/TypeInfo.tsx
+++ b/packages/site/src/components/TypeInfo/TypeInfo.tsx
@@ -1,8 +1,9 @@
-import { type HTMLAttributes, type ReactNode, type ElementType } from 'react'
+import type { HTMLAttributes, ReactNode, ElementType } from 'react'
+import type { ExtractedTypeInfo } from '../../utils/getTypeDocs'
 import { merge } from '@trikinco/fullstack-components/utils'
-import { IconMenuAlt } from './Icons/IconMenuAlt'
-import { Accordion } from './Accordion'
-import { type ExtractedTypeInfo } from '../utils/getTypeDocs'
+import { TypeInfoTags } from './TypeInfoTags'
+import { IconMenuAlt } from '../Icons/IconMenuAlt'
+import { Accordion } from '../Accordion'
 
 export interface TypeInfoDetails
 	extends Omit<
@@ -44,6 +45,9 @@ export interface TypeInfoProps
 	component?: ElementType
 }
 
+/**
+ * Renders type information extracted from a .d.ts file with `getTypeDocs`
+ */
 export const TypeInfo = ({
 	name,
 	type,
@@ -54,6 +58,7 @@ export const TypeInfo = ({
 	children,
 	className,
 	tags,
+	id,
 	component: TitleComponent = 'p',
 	...rest
 }: TypeInfoProps) => {
@@ -66,7 +71,7 @@ export const TypeInfo = ({
 			{...rest}
 		>
 			{!hideName && (
-				<TitleComponent className="flex gap-2 m-0">
+				<TitleComponent className="flex gap-2 m-0 scroll-mt-10" id={id}>
 					{name && <span className="font-bold">{name}</span>}
 					{type && (
 						<span className="text-sm font-mono my-auto text-slate-500">
@@ -87,18 +92,7 @@ export const TypeInfo = ({
 				</span>
 			)}
 
-			{tags && tags.length > 0 && (
-				<ul className="not-prose">
-					{tags.map(({ name, value }) => (
-						<li key={name}>
-							<span className="font-bold text-[--shiki-token-keyword] mr-2">
-								{name}
-							</span>
-							{value}
-						</li>
-					))}
-				</ul>
-			)}
+			<TypeInfoTags tags={tags} />
 
 			{parameters && parameters.length > 0 && (
 				<Accordion

--- a/packages/site/src/components/TypeInfo/TypeInfoTags.tsx
+++ b/packages/site/src/components/TypeInfo/TypeInfoTags.tsx
@@ -1,0 +1,56 @@
+import type { DetailedHTMLProps, HTMLAttributes } from 'react'
+import type { ExtractedTypeInfo } from '../../utils/getTypeDocs'
+import { merge } from '@trikinco/fullstack-components/utils'
+import { isValidUrl } from '../../utils/isValidUrl'
+
+export interface TypeInfoTagsProps
+	extends DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+	tags: ExtractedTypeInfo['tags']
+	listProps?: DetailedHTMLProps<
+		HTMLAttributes<HTMLUListElement>,
+		HTMLUListElement
+	>
+}
+
+/**
+ * Renders a list of tags from a type
+ */
+export const TypeInfoTags = ({
+	tags,
+	listProps,
+	...rest
+}: TypeInfoTagsProps) => {
+	const { className: listClassName, ...listRest } = listProps || {}
+	return (
+		<div {...rest}>
+			{tags && tags.length > 0 && (
+				<ul className={merge('not-prose', listClassName)} {...listRest}>
+					{tags.map(({ name, value }) => {
+						const firstWord =
+							typeof value === 'string' ? value.split(' ')[0] : ''
+						const isLinkTag = name === 'link'
+						const isUrl = isValidUrl(firstWord)
+
+						return (
+							<li key={name}>
+								<span className="font-bold text-[--shiki-token-keyword] mr-2">
+									{name}
+								</span>
+								{isLinkTag && !!firstWord ? (
+									<a
+										href={isUrl ? firstWord : `#${firstWord}`}
+										className="hover:underline rounded-sm focus-ring"
+									>
+										{value}
+									</a>
+								) : (
+									value
+								)}
+							</li>
+						)
+					})}
+				</ul>
+			)}
+		</div>
+	)
+}

--- a/packages/site/src/components/TypeInfo/TypeInfoToText.tsx
+++ b/packages/site/src/components/TypeInfo/TypeInfoToText.tsx
@@ -1,9 +1,9 @@
 import type { HTMLAttributes, ReactNode } from 'react'
 import { merge } from '@trikinco/fullstack-components/utils'
 import { TypeInfo, type TypeInfoDetails } from './TypeInfo'
-import { getTypeDocs } from '../utils/getTypeDocs'
+import { getTypeDocs } from '../../utils/getTypeDocs'
 
-export interface TypesToMdxProps
+export interface TypeInfoToTextProps
 	extends Omit<HTMLAttributes<HTMLDivElement>, 'title'>,
 		Omit<TypeInfoDetails, 'name'> {
 	children?: ReactNode
@@ -30,7 +30,10 @@ export interface TypesToMdxProps
 	basePath: string
 }
 
-export const TypesToMdx = async ({
+/**
+ * Extracts type information from a .d.ts file with `getTypeDocs` and renders it
+ */
+export const TypeInfoToText = async ({
 	basePath = '../fullstack-components/dist/',
 	path: filePath,
 	name,
@@ -41,7 +44,7 @@ export const TypesToMdx = async ({
 	children,
 	className,
 	...rest
-}: TypesToMdxProps) => {
+}: TypeInfoToTextProps) => {
 	const path = basePath + filePath
 	const { properties, parameters, ...schema } = await getTypeDocs(path, name)
 	const hasParameters = parameters && parameters?.length > 0

--- a/packages/site/src/components/TypeInfo/TypeInfoToText.tsx
+++ b/packages/site/src/components/TypeInfo/TypeInfoToText.tsx
@@ -51,7 +51,7 @@ export const TypeInfoToText = async ({
 
 	return (
 		<div
-			className={merge('typedoc inline-flex flex-col w-full mb-8', className)}
+			className={merge('inline-flex flex-col w-full mb-8', className)}
 			{...rest}
 		>
 			<TypeInfo

--- a/packages/site/src/components/TypesToMdx.tsx
+++ b/packages/site/src/components/TypesToMdx.tsx
@@ -1,0 +1,86 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+import { merge } from '@trikinco/fullstack-components/utils'
+import { getTypeDocs } from '@/src/utils/getTypeDocs'
+import { TypeInfo } from './TypeInfo'
+
+export interface TypesToMdxProps
+	extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
+	children?: ReactNode
+	/**
+	 * Relative path to the fileName to extract types from
+	 * @example
+	 * 'src/components/Button.tsx'
+	 */
+	path: string
+	/**
+	 * Name of the type or interface to extract.
+	 * Needed to extract a single type from a .ts/x file
+	 * @example
+	 * 'ButtonProps'
+	 */
+	name: string
+	/**
+	 * Title to override the top level type `name`
+	 */
+	title?: ReactNode
+	/**
+	 * Hides the top level type `name` or `title`
+	 */
+	hideTitle?: boolean
+	/**
+	 * Description to override the top level type description
+	 */
+	description?: ReactNode
+}
+
+export const TypesToMdx = async ({
+	path,
+	name,
+	title,
+	hideTitle,
+	description,
+	children,
+	className,
+	...rest
+}: TypesToMdxProps) => {
+	const markdown = await getTypeDocs(path, name)
+
+	return (
+		<div
+			className={merge('typedoc inline-flex flex-col w-full mb-8', className)}
+			{...rest}
+		>
+			{!hideTitle && (
+				<span
+					className="text-xl font-bold mb-3 [&>*]:m-0"
+					dangerouslySetInnerHTML={{ __html: title || markdown.name }}
+				/>
+			)}
+			{(description || markdown.description) && (
+				<span
+					className="text-lg mt-0 mb-3 whitespace-pre-wrap [&>*]:m-0"
+					dangerouslySetInnerHTML={{
+						__html: description || markdown.description || '',
+					}}
+				/>
+			)}
+
+			{markdown.properties.length > 0 && (
+				<div className="flex flex-col mt-6">
+					{markdown.properties.map(
+						({ name, type, required, description, parameters }) => (
+							<TypeInfo
+								key={name}
+								name={name}
+								type={type}
+								required={required}
+								description={description}
+								parameters={parameters}
+							/>
+						)
+					)}
+				</div>
+			)}
+		</div>
+	)
+}

--- a/packages/site/src/styles/globals.css
+++ b/packages/site/src/styles/globals.css
@@ -40,26 +40,7 @@ body {
 [data-rehype-pretty-code-fragment] {
 	font-variant-ligatures: none;
 	background-color: var(--shiki-color-background);
-	@apply relative overflow-hidden my-10 font-mono;
-}
-
-[data-rehype-pretty-code-fragment]:not(
-		.typedoc [data-rehype-pretty-code-fragment]
-	) {
-	@apply rounded-lg border border-slate-300 dark:border-white/20;
-}
-
-.typedoc [data-rehype-pretty-code-fragment] {
-	@apply mr-2;
-}
-
-.typedoc a code {
-	@apply underline;
-}
-
-.typedoc [data-rehype-pretty-code-fragment] code::before,
-.typedoc [data-rehype-pretty-code-fragment] code::after {
-	content: none;
+	@apply relative overflow-hidden my-10 font-mono rounded-lg border border-slate-300 dark:border-white/20;
 }
 
 /* hide copy button for code blocks with a `title` including `:nocopy` */

--- a/packages/site/src/styles/globals.css
+++ b/packages/site/src/styles/globals.css
@@ -40,7 +40,22 @@ body {
 [data-rehype-pretty-code-fragment] {
 	font-variant-ligatures: none;
 	background-color: var(--shiki-color-background);
-	@apply relative overflow-hidden my-10 font-mono rounded-lg border border-slate-300 dark:border-white/20;
+	@apply relative overflow-hidden my-10 font-mono;
+}
+
+[data-rehype-pretty-code-fragment]:not(
+		.typedoc [data-rehype-pretty-code-fragment]
+	) {
+	@apply rounded-lg border border-slate-300 dark:border-white/20;
+}
+
+.typedoc [data-rehype-pretty-code-fragment] {
+	@apply mr-2;
+}
+
+.typedoc [data-rehype-pretty-code-fragment] code::before,
+.typedoc [data-rehype-pretty-code-fragment] code::after {
+	content: none;
 }
 
 /* hide copy button for code blocks with a `title` including `:nocopy` */

--- a/packages/site/src/styles/globals.css
+++ b/packages/site/src/styles/globals.css
@@ -53,6 +53,10 @@ body {
 	@apply mr-2;
 }
 
+.typedoc a code {
+	@apply underline;
+}
+
 .typedoc [data-rehype-pretty-code-fragment] code::before,
 .typedoc [data-rehype-pretty-code-fragment] code::after {
 	content: none;

--- a/packages/site/src/styles/globals.css
+++ b/packages/site/src/styles/globals.css
@@ -8,7 +8,7 @@
 	--shiki-color-background: hsla(0, 0%, 98%, 1);
 	--shiki-token-constant: hsla(211, 100%, 42%, 1);
 	--shiki-token-string: hsla(133, 50%, 32%, 1);
-	--shiki-token-comment: hsla(0, 0%, 40%, 1);
+	--shiki-token-comment: hsla(215.38, 16.32%, 46.86%, 1);
 	--shiki-token-keyword: hsla(336, 65%, 45%, 1);
 	--shiki-token-parameter: hsla(30, 100%, 32%, 1);
 	--shiki-token-function: hsla(274, 71%, 43%, 1);
@@ -23,7 +23,7 @@
 	--shiki-color-background: transparent;
 	--shiki-token-constant: hsla(210, 100%, 66%, 1);
 	--shiki-token-string: hsla(131, 43%, 57%, 1);
-	--shiki-token-comment: hsla(0, 0%, 63%, 1);
+	--shiki-token-comment: hsla(215, 20.22%, 65.1%, 1);
 	--shiki-token-keyword: hsla(341, 90%, 67%, 1);
 	--shiki-token-parameter: hsla(35, 100%, 52%, 1);
 	--shiki-token-function: hsla(275, 80%, 71%, 1);
@@ -69,7 +69,7 @@ body {
 
 /* code block `title` (usually the file name) */
 [data-rehype-pretty-code-title] {
-	@apply ml-5 mt-4 text-slate-400;
+	@apply ml-5 mt-4 text-slate-500 dark:text-slate-400;
 }
 
 [data-highlighted-chars] {

--- a/packages/site/src/utils/fonts.ts
+++ b/packages/site/src/utils/fonts.ts
@@ -7,7 +7,7 @@ export const fontBase = Space_Grotesk({
 
 export const fontMono = Space_Mono({
 	subsets: ['latin'],
-	weight: '400',
+	weight: ['400', '700'],
 	variable: '--font-mono',
 })
 

--- a/packages/site/src/utils/getTypeDocs.ts
+++ b/packages/site/src/utils/getTypeDocs.ts
@@ -1,0 +1,234 @@
+import ts from 'typescript'
+import fs from 'fs'
+import path from 'path'
+import { markdownToHtml } from './markdown'
+
+type ExtractedTypeInfo = {
+	/** Name of the type/interface */
+	name: string
+	/** Typedoc descriptions */
+	description: string | undefined
+	/** The type */
+	type: string
+	/** Parameters if the type is a function */
+	parameters: ExtractedTypeInfo[] | undefined
+	/** Whether the type is required or optional */
+	required: boolean
+}
+
+/**
+ * An object interface or type
+ */
+type ExtractedTypes = Omit<ExtractedTypeInfo, 'required'> & {
+	/**
+	 * Each individual prop in the object type
+	 */
+	properties: ExtractedTypeInfo[]
+}
+
+/**
+ * Parses JSDoc comments and returns clean strings
+ */
+function parseJSDocCommentsAndTags(
+	hostNode: ts.Node,
+	sourceFile: ts.SourceFile
+) {
+	const comment = ts
+		.getJSDocCommentsAndTags(hostNode)
+		.map((doc) => doc.getText(sourceFile))
+		.join('')
+
+	const extractedComments = comment.match(/\/\*\*\s*([\s\S]*?)\s*\*\//)
+
+	const parsedComment = extractedComments?.[1]
+		.replaceAll(/^\s*\*\s*/gm, '') // Remove leading asterisks and spaces on each line
+		.replaceAll(/@(\w+)/g, '`$1{:sh}`')
+		.trim() // Trim leading and trailing whitespace
+
+	return parsedComment || ''
+}
+
+/**
+ * Checks whether a node is a function or method
+ *
+ * @example function type
+ * onError: (event: Event) => void
+ */
+function isNodeFunctionType(node: ts.Node) {
+	const member = node as ts.PropertySignature
+
+	// @note `ts.SyntaxKind` number references may change across TS versions
+	return (
+		// 184
+		member.type?.kind === ts.SyntaxKind.FunctionType ||
+		// 173
+		member.type?.kind === ts.SyntaxKind.MethodSignature
+	)
+}
+
+function isMatchingNodeInterface(node: ts.Node, typeName: string) {
+	return (
+		(ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) &&
+		node.name.text === typeName
+	)
+}
+
+/**
+ * Gets the node `type` name
+ *
+ * @example type names
+ * string | number | function | unknown
+ */
+function getNodeType(sourceFile: ts.SourceFile, node?: ts.Node) {
+	if (!node) return 'object'
+
+	const member = node as ts.PropertySignature
+	const type = member?.type?.getText(sourceFile) ?? 'unknown'
+
+	if (!ts.isPropertySignature(member)) {
+		return type
+	}
+
+	if (isNodeFunctionType(member)) {
+		return 'function'
+	}
+
+	return type
+}
+
+/**
+ * Gets all the properties and parameters for a node
+ */
+function getNodeProperty(
+	node: ts.PropertySignature | ts.ParameterDeclaration,
+	sourceFile: ts.SourceFile
+) {
+	const name = node.name.getText(sourceFile)
+	const description = parseJSDocCommentsAndTags(node, sourceFile)
+	const required = !node.questionToken
+	const type = getNodeType(sourceFile, node)
+	const parameters = getNodeParameters(node, sourceFile)
+
+	return {
+		name,
+		type,
+		description,
+		required,
+		parameters,
+		// Additional handling for enum + other types can be added here
+	}
+}
+
+/**
+ * Recursively gets all parameters for a node
+ */
+function getNodeParameters(
+	node: ts.Node,
+	sourceFile: ts.SourceFile
+): ExtractedTypeInfo[] {
+	if (!ts.isPropertySignature(node) || !isNodeFunctionType(node)) return []
+
+	const member = node.type as ts.FunctionTypeNode
+	const members = member?.parameters || member?.typeParameters
+
+	return members?.map((param) => getNodeProperty(param, sourceFile)) || []
+}
+
+/**
+ * Recursively gets all parameters for a node
+ */
+function getTypeProperties(typeName: string, sourceFile: ts.SourceFile) {
+	let properties: ExtractedTypeInfo[] = []
+
+	ts.forEachChild(sourceFile, (node) => {
+		if (!isMatchingNodeInterface(node, typeName)) return
+
+		node.forEachChild((member) => {
+			if (!ts.isPropertySignature(member)) return
+
+			const property = getNodeProperty(member, sourceFile)
+			properties.push(property)
+		})
+	})
+
+	return properties
+}
+
+function getTypeDescription(typeName: string, sourceFile: ts.SourceFile) {
+	let description = ''
+
+	ts.forEachChild(sourceFile, (node) => {
+		if (!isMatchingNodeInterface(node, typeName)) return
+
+		description = parseJSDocCommentsAndTags(node, sourceFile)
+	})
+
+	return description
+}
+
+/**
+ * Formats a type's comment and all it's members comments to HTML
+ *
+ * @consideration format parameter comments?
+ */
+async function formatComments(
+	description: string | undefined,
+	properties: ExtractedTypeInfo[]
+) {
+	const descriptions = [
+		description,
+		...properties.map((value) => value.description),
+	]
+
+	const data = await Promise.allSettled(
+		descriptions.map((text) => markdownToHtml(text).then((file) => file.value))
+	)
+	const response = data.filter(
+		(res) => res.status === 'fulfilled'
+	) as PromiseFulfilledResult<string | undefined>[]
+
+	return response
+}
+
+/**
+ * Extracts type information and formats descriptions to HTML.
+ *
+ * @example filePath
+ * 'src/components/Button.tsx'
+ *
+ * @note only handles simple objects like interfaces and types.
+ * Does not handle parsing the heritage clauses of the interface declaration.
+ * e.g extracting type info from extended interfaces and types using Pick, Omit, etc.
+ */
+export async function getTypeDocs(
+	filePath: string,
+	typeName: string
+): Promise<ExtractedTypes> {
+	const sourceFile = ts.createSourceFile(
+		path.join(process.cwd(), filePath),
+		fs.readFileSync(filePath).toString(),
+		ts.ScriptTarget.ES2015,
+		true
+	)
+
+	const type = getNodeType(sourceFile)
+	const description = getTypeDescription(typeName, sourceFile)
+	const properties = getTypeProperties(typeName, sourceFile)
+	const response = await formatComments(description, properties)
+
+	return {
+		name: typeName,
+		type,
+		parameters: [],
+		description: response[0].value,
+		properties: properties.map((property, i) => ({
+			name: property.name,
+			type: property.type,
+			required: property.required,
+			parameters: property.parameters,
+			description: response[i + 1].value,
+		})),
+	}
+}
+
+export default getTypeDocs

--- a/packages/site/src/utils/getTypeDocs.ts
+++ b/packages/site/src/utils/getTypeDocs.ts
@@ -7,6 +7,9 @@ import {
 
 export type ExtractedTagValue = string | number | boolean
 
+/**
+ * JSDoc tags that are extracted from a type
+ */
 export type ExtractedTags = {
 	note?: ExtractedTagValue
 	see?: ExtractedTagValue
@@ -32,7 +35,9 @@ export type ExtractedTypeInfo = {
 	properties?: ExtractedTypeInfo[] | undefined
 	/** Whether the type is required or optional */
 	required?: boolean
-	// tags
+	/**
+	 * Extracted JSdoc tags
+	 */
 	tags?: {
 		name: string
 		value: ExtractedTagValue
@@ -41,6 +46,9 @@ export type ExtractedTypeInfo = {
 
 type TaggableSchema = ICodeSchema & ExtractedTags
 
+/**
+ * Type guard that checks if a schema/type may have JSDoc tags
+ */
 export function isTaggableSchema(
 	schema?: TaggableSchema | null
 ): schema is TaggableSchema {
@@ -56,9 +64,15 @@ export function isTaggableSchema(
 	)
 }
 
+/**
+ * Cleans up a $ref value generated for a type by `@wix/typescript-schema-extract`
+ */
 const cleanRef = (ref?: string) =>
 	ref?.split('#').pop()?.split(' ').pop()?.split('!').pop()?.trim()
 
+/**
+ * Extracts and cleans up the type name from a type
+ */
 const getTypeName = (node: SchemaTypes) => {
 	const base = node['$ref']?.includes('#') ? '' : node['$ref']?.split('/').pop()
 	const oneOf = node.oneOf
@@ -96,6 +110,9 @@ const getTypeName = (node: SchemaTypes) => {
 	return type?.split('React.').pop() || type
 }
 
+/**
+ * Extracts JSDoc tags from a type comment
+ */
 const getItemTags = (item: ICodeSchema) => {
 	let tags: ExtractedTypeInfo['tags'] = []
 
@@ -118,6 +135,9 @@ const getItemTags = (item: ICodeSchema) => {
 	return tags
 }
 
+/**
+ * Extracts arguments from a function schema
+ */
 const getItemArguments = (item: ICodeSchema, typeName?: string) => {
 	let parameters = undefined
 
@@ -130,6 +150,9 @@ const getItemArguments = (item: ICodeSchema, typeName?: string) => {
 	return parameters
 }
 
+/**
+ * Extracts type info from a schema
+ */
 const getExtractedTypeInfo = (
 	item: ICodeSchema,
 	typeName?: string,
@@ -158,6 +181,9 @@ const getExtractedTypeInfo = (
 	}
 }
 
+/**
+ * Extracts type info from a d.ts file
+ */
 export async function getTypeDocs(
 	filePath: string,
 	typeName: string
@@ -165,8 +191,6 @@ export async function getTypeDocs(
 	const files = [filePath]
 	const linker = createLinker(files)
 	const schema = linker.flatten(files[0], typeName)
-
-	// Extract the type info
 	const data = getExtractedTypeInfo(schema, typeName)
 
 	return data

--- a/packages/site/src/utils/isValidUrl.ts
+++ b/packages/site/src/utils/isValidUrl.ts
@@ -1,0 +1,14 @@
+/**
+ * Check if a string is a valid HTTP/S URL.
+ */
+export function isValidUrl(text: string) {
+	let url
+
+	try {
+		url = new URL(text)
+	} catch (_error) {
+		return false
+	}
+
+	return url.protocol === 'http:' || url.protocol === 'https:'
+}

--- a/packages/site/src/utils/markdown.ts
+++ b/packages/site/src/utils/markdown.ts
@@ -1,24 +1,4 @@
-import { unified, type Processor } from 'unified'
-import rehypeStringify from 'rehype-stringify'
-import remarkParse from 'remark-parse'
-import rehypePrettyCode from 'rehype-pretty-code'
-import remarkRehype from 'remark-rehype'
 import { CodeBlock } from '../components/CodeBlock'
-
-/**
- * Converts a vfile/string into HTML.
- * Highlights code with rehype-pretty-code
- */
-export function markdownToHtml(file: Parameters<Processor['process']>[0]) {
-	return unified()
-		.use(remarkParse)
-		.use(remarkRehype)
-		.use(rehypePrettyCode, {
-			theme: 'css-variables',
-		})
-		.use(rehypeStringify)
-		.process(file)
-}
 
 /**
  * Default components to use for

--- a/packages/site/src/utils/markdown.ts
+++ b/packages/site/src/utils/markdown.ts
@@ -1,4 +1,24 @@
+import { unified, type Processor } from 'unified'
+import rehypeStringify from 'rehype-stringify'
+import remarkParse from 'remark-parse'
+import rehypePrettyCode from 'rehype-pretty-code'
+import remarkRehype from 'remark-rehype'
 import { CodeBlock } from '../components/CodeBlock'
+
+/**
+ * Converts a vfile/string into HTML.
+ * Highlights code with rehype-pretty-code
+ */
+export function markdownToHtml(file: Parameters<Processor['process']>[0]) {
+	return unified()
+		.use(remarkParse)
+		.use(remarkRehype)
+		.use(rehypePrettyCode, {
+			theme: 'css-variables',
+		})
+		.use(rehypeStringify)
+		.process(file)
+}
 
 /**
  * Default components to use for

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,24 +177,12 @@ importers:
       rehype-slug:
         specifier: 6.0.0
         version: 6.0.0
-      rehype-stringify:
-        specifier: 10.0.0
-        version: 10.0.0
       remark-gfm:
         specifier: 4.0.0
         version: 4.0.0
-      remark-parse:
-        specifier: 11.0.0
-        version: 11.0.0
-      remark-rehype:
-        specifier: 11.0.0
-        version: 11.0.0
       shiki:
         specifier: 0.14.5
         version: 0.14.5
-      unified:
-        specifier: 11.0.4
-        version: 11.0.4
       unist-util-visit:
         specifier: 5.0.0
         version: 5.0.0
@@ -9377,24 +9365,6 @@ packages:
       '@types/hast': 3.0.3
     dev: false
 
-  /hast-util-raw@9.0.1:
-    resolution: {integrity: sha512-5m1gmba658Q+lO5uqL5YNGQWeh1MYWZbZmWrM5lncdcuiXuo5E2HT/CIOp0rLF8ksfSwiCVJ3twlgVRyTGThGA==}
-    dependencies:
-      '@types/hast': 3.0.3
-      '@types/unist': 3.0.2
-      '@ungap/structured-clone': 1.2.0
-      hast-util-from-parse5: 8.0.1
-      hast-util-to-parse5: 8.0.0
-      html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.0.2
-      parse5: 7.1.2
-      unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
-      vfile: 6.0.1
-      web-namespaces: 2.0.1
-      zwitch: 2.0.4
-    dev: false
-
   /hast-util-to-estree@3.1.0:
     resolution: {integrity: sha512-lfX5g6hqVh9kjS/B9E2gSkvHH4SZNiQFiqWS0x9fENzEl+8W12RqdRxX6d/Cwxi30tPQs3bIO+aolQJNp1bIyw==}
     dependencies:
@@ -9418,23 +9388,6 @@ packages:
       - supports-color
     dev: false
 
-  /hast-util-to-html@9.0.0:
-    resolution: {integrity: sha512-IVGhNgg7vANuUA2XKrT6sOIIPgaYZnmLx3l/CCOAK0PtgfoHrZwX7jCSYyFxHTrGmC6S9q8aQQekjp4JPZF+cw==}
-    dependencies:
-      '@types/hast': 3.0.3
-      '@types/unist': 3.0.2
-      ccount: 2.0.1
-      comma-separated-tokens: 2.0.3
-      hast-util-raw: 9.0.1
-      hast-util-whitespace: 3.0.0
-      html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.0.2
-      property-information: 6.4.0
-      space-separated-tokens: 2.0.2
-      stringify-entities: 4.0.3
-      zwitch: 2.0.4
-    dev: false
-
   /hast-util-to-jsx-runtime@2.3.0:
     resolution: {integrity: sha512-H/y0+IWPdsLLS738P8tDnrQ8Z+dj12zQQ6WC11TIM21C8WFVoIxcqWXf2H3hiTVZjF1AWqoimGwrTWecWrnmRQ==}
     dependencies:
@@ -9455,18 +9408,6 @@ packages:
       vfile-message: 4.0.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /hast-util-to-parse5@8.0.0:
-    resolution: {integrity: sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==}
-    dependencies:
-      '@types/hast': 3.0.3
-      comma-separated-tokens: 2.0.3
-      devlop: 1.1.0
-      property-information: 6.4.0
-      space-separated-tokens: 2.0.2
-      web-namespaces: 2.0.1
-      zwitch: 2.0.4
     dev: false
 
   /hast-util-to-string@3.0.0:
@@ -9552,10 +9493,6 @@ packages:
     resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
     engines: {node: '>=8'}
     dev: true
-
-  /html-void-elements@3.0.0:
-    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
-    dev: false
 
   /html-webpack-plugin@5.5.3(webpack@5.89.0):
     resolution: {integrity: sha512-6YrDKTuqaP/TquFH7h4srYWsZx+x6k6+FbsTm0ziCwGHDP78Unr1r9F/H4+sGmMbX08GQcJ+K64x55b+7VM/jg==}
@@ -13685,14 +13622,6 @@ packages:
       hast-util-heading-rank: 3.0.0
       hast-util-to-string: 3.0.0
       unist-util-visit: 5.0.0
-    dev: false
-
-  /rehype-stringify@10.0.0:
-    resolution: {integrity: sha512-1TX1i048LooI9QoecrXy7nGFFbFSufxVRAfc6Y9YMRAi56l+oB0zP51mLSV312uRuvVLPV1opSlJmslozR1XHQ==}
-    dependencies:
-      '@types/hast': 3.0.3
-      hast-util-to-html: 9.0.0
-      unified: 11.0.4
     dev: false
 
   /relateurl@0.2.7:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,12 +174,24 @@ importers:
       rehype-slug:
         specifier: 6.0.0
         version: 6.0.0
+      rehype-stringify:
+        specifier: 10.0.0
+        version: 10.0.0
       remark-gfm:
         specifier: 4.0.0
         version: 4.0.0
+      remark-parse:
+        specifier: 11.0.0
+        version: 11.0.0
+      remark-rehype:
+        specifier: 11.0.0
+        version: 11.0.0
       shiki:
         specifier: 0.14.5
         version: 0.14.5
+      unified:
+        specifier: 11.0.4
+        version: 11.0.4
       unist-util-visit:
         specifier: 5.0.0
         version: 5.0.0
@@ -9324,6 +9336,24 @@ packages:
       '@types/hast': 3.0.3
     dev: false
 
+  /hast-util-raw@9.0.1:
+    resolution: {integrity: sha512-5m1gmba658Q+lO5uqL5YNGQWeh1MYWZbZmWrM5lncdcuiXuo5E2HT/CIOp0rLF8ksfSwiCVJ3twlgVRyTGThGA==}
+    dependencies:
+      '@types/hast': 3.0.3
+      '@types/unist': 3.0.2
+      '@ungap/structured-clone': 1.2.0
+      hast-util-from-parse5: 8.0.1
+      hast-util-to-parse5: 8.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.0.2
+      parse5: 7.1.2
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.1
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+    dev: false
+
   /hast-util-to-estree@3.1.0:
     resolution: {integrity: sha512-lfX5g6hqVh9kjS/B9E2gSkvHH4SZNiQFiqWS0x9fENzEl+8W12RqdRxX6d/Cwxi30tPQs3bIO+aolQJNp1bIyw==}
     dependencies:
@@ -9347,6 +9377,23 @@ packages:
       - supports-color
     dev: false
 
+  /hast-util-to-html@9.0.0:
+    resolution: {integrity: sha512-IVGhNgg7vANuUA2XKrT6sOIIPgaYZnmLx3l/CCOAK0PtgfoHrZwX7jCSYyFxHTrGmC6S9q8aQQekjp4JPZF+cw==}
+    dependencies:
+      '@types/hast': 3.0.3
+      '@types/unist': 3.0.2
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-raw: 9.0.1
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.0.2
+      property-information: 6.4.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.3
+      zwitch: 2.0.4
+    dev: false
+
   /hast-util-to-jsx-runtime@2.3.0:
     resolution: {integrity: sha512-H/y0+IWPdsLLS738P8tDnrQ8Z+dj12zQQ6WC11TIM21C8WFVoIxcqWXf2H3hiTVZjF1AWqoimGwrTWecWrnmRQ==}
     dependencies:
@@ -9367,6 +9414,18 @@ packages:
       vfile-message: 4.0.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /hast-util-to-parse5@8.0.0:
+    resolution: {integrity: sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==}
+    dependencies:
+      '@types/hast': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 6.4.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
     dev: false
 
   /hast-util-to-string@3.0.0:
@@ -9452,6 +9511,10 @@ packages:
     resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
     engines: {node: '>=8'}
     dev: true
+
+  /html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+    dev: false
 
   /html-webpack-plugin@5.5.3(webpack@5.89.0):
     resolution: {integrity: sha512-6YrDKTuqaP/TquFH7h4srYWsZx+x6k6+FbsTm0ziCwGHDP78Unr1r9F/H4+sGmMbX08GQcJ+K64x55b+7VM/jg==}
@@ -13584,6 +13647,14 @@ packages:
       hast-util-heading-rank: 3.0.0
       hast-util-to-string: 3.0.0
       unist-util-visit: 5.0.0
+    dev: false
+
+  /rehype-stringify@10.0.0:
+    resolution: {integrity: sha512-1TX1i048LooI9QoecrXy7nGFFbFSufxVRAfc6Y9YMRAi56l+oB0zP51mLSV312uRuvVLPV1opSlJmslozR1XHQ==}
+    dependencies:
+      '@types/hast': 3.0.3
+      hast-util-to-html: 9.0.0
+      unified: 11.0.4
     dev: false
 
   /relateurl@0.2.7:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       '@vercel/analytics':
         specifier: 1.1.1
         version: 1.1.1
+      '@wix/typescript-schema-extract':
+        specifier: 1.0.3
+        version: 1.0.3(typescript@5.2.2)
       ai:
         specifier: 2.2.20
         version: 2.2.20(react@18.2.0)(solid-js@1.8.7)(svelte@4.2.8)(vue@3.3.10)
@@ -2093,6 +2096,37 @@ packages:
   /@fal-works/esbuild-plugin-global-externals@2.1.2:
     resolution: {integrity: sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==}
     dev: true
+
+  /@file-services/memory@1.0.7:
+    resolution: {integrity: sha512-VCAbNiEIlegFsLGtrhJ09cAbvumHXLpQvXHanlf3f2WIrb7xEIsc8Z++ScO/O0C6kYAZg1diXZpJTMUUyV21GQ==}
+    dependencies:
+      '@file-services/posix-path': 1.0.3
+      '@file-services/types': 1.0.4
+      '@file-services/utils': 1.0.4
+    dev: false
+
+  /@file-services/posix-path@1.0.3:
+    resolution: {integrity: sha512-m6WuGAyIku8jVXr2DP0TTZnaBXCjAobk1YS+EciVRUQvbjxswPqpV7L3yqmYFfYuExHLNcoA+puKYL556nbW0Q==}
+    dev: false
+
+  /@file-services/types@1.0.4:
+    resolution: {integrity: sha512-t0u+YU3DRAEZzhIU4cKJetOdvsevrfBwKIStvmxNc3GvR0zoDkuhpAnfgqYrf6aRAvM22G6/CkaU7PKIwacvOw==}
+    dev: false
+
+  /@file-services/typescript@1.0.5(typescript@5.2.2):
+    resolution: {integrity: sha512-uZ15YkwB3HNvNUtqKbuozefngsHiN4fvAuBDNqOGFHPsd8NTXlMo/V0ET11to2MyKYkPdUswVlkFjxLiWhKixQ==}
+    peerDependencies:
+      typescript: '>=2.8.0'
+    dependencies:
+      '@file-services/types': 1.0.4
+      typescript: 5.2.2
+    dev: false
+
+  /@file-services/utils@1.0.4:
+    resolution: {integrity: sha512-b2gf6TWcSacw5NuOR7UWqNK8iHpQU1hbhwFT0A+3k0oRMH1JA3vOeXIlxRaqAflCRYi4Qd4OQ5JBtTKDH4bSVA==}
+    dependencies:
+      '@file-services/types': 1.0.4
+    dev: false
 
   /@floating-ui/core@1.5.2:
     resolution: {integrity: sha512-Ii3MrfY/GAIN3OhXNzpCKaLxHQfJF9qvwq/kEJYdqDxeIHa01K8sldugal6TmeeXl+WMvhv9cnVzUTaFFJF09A==}
@@ -5626,6 +5660,18 @@ packages:
       '@webassemblyjs/ast': 1.11.6
       '@xtuc/long': 4.2.2
 
+  /@wix/typescript-schema-extract@1.0.3(typescript@5.2.2):
+    resolution: {integrity: sha512-3PZfDNJl7Bo7uRfsqBtbeuLpge1W4LeMqe6JtLaomBTlmF/G+Bgu/pYWakMluqixJlHZrap3eXi2TlQ2YwwlMg==}
+    peerDependencies:
+      typescript: '>=2.8.0'
+    dependencies:
+      '@file-services/memory': 1.0.7
+      '@file-services/typescript': 1.0.5(typescript@5.2.2)
+      '@types/json-schema': 7.0.15
+      glob: 7.2.3
+      typescript: 5.2.2
+    dev: false
+
   /@xtuc/ieee754@1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -6313,7 +6359,6 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
 
   /base-64@0.1.0:
     resolution: {integrity: sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==}
@@ -6404,7 +6449,6 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-    dev: true
 
   /brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
@@ -6972,7 +7016,6 @@ packages:
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-    dev: true
 
   /concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -8897,7 +8940,6 @@ packages:
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-    dev: true
 
   /fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -9109,7 +9151,6 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
-    dev: true
 
   /global-dirs@0.1.1:
     resolution: {integrity: sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==}
@@ -9707,7 +9748,6 @@ packages:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
-    dev: true
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -11838,7 +11878,6 @@ packages:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
-    dev: true
 
   /minimatch@5.1.6:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
@@ -12671,7 +12710,6 @@ packages:
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}


### PR DESCRIPTION
Changes to library types and type documentation:
- Rewrites the comments for all features to display in the docs
- Adds consistent JSDoc tags to comments
- Prefer normal functions over arrow functions for component docs consistency
- Prefer destructuring component props in the function body over inline destructuring for docs consistency
- Prefer interfaces over classes for library features for reusability and docs consistency
- Prefer explicit repetition of function and component types over type merging and extends to make type documentation clearer (this simplicity outweighs the effort of unwrapping complex types)

Other library changes:
- Fall back to stringified empty object to avoid Server Components from crashing due to unexpected end of JSON (should be improved further in the future)

Changes to site docs:
- Adds "API Reference" section that displays type information for relevant library exports to all docs pages
- Use a component-based approach to extract type docs to allow for more flexibility to restructure docs and change the layout and design
- Ensure consistent font weights and colours with sufficient contrast for muted and mono content 
- Adds new menu icon

![Screenshot 2023-12-20 at 15 13 41](https://github.com/trikinco/fullstack-components/assets/7847281/6f6061cf-1ac7-4f62-a1ce-ede4eb5ec2b9)
![Screenshot 2023-12-20 at 15 14 20](https://github.com/trikinco/fullstack-components/assets/7847281/8148013d-2267-4c26-a9f9-2539f41a55b1)
