### PR TITLE
fix: Return the correct content format for Prompt and allow setting JSON mode explicitly

### DIFF
--- a/packages/fullstack-components/src/chatGptService.ts
+++ b/packages/fullstack-components/src/chatGptService.ts
@@ -14,7 +14,7 @@ export type ChatGptCompletionResponse<T = string> = {
 	errorMessage?: string
 }
 
-export type ChatCompletionFormat = 'JSON'
+export type ChatCompletionFormat = 'JSON' | 'text'
 
 export type ChatCompletionsOptions = Omit<
 	OpenAI.ChatCompletionCreateParamsNonStreaming,

--- a/packages/fullstack-components/src/handlers/prompt/models.ts
+++ b/packages/fullstack-components/src/handlers/prompt/models.ts
@@ -14,6 +14,17 @@ export interface PromptRequestBody {
 	 * @link https://www.npmjs.com/package/openai `openai` for full `OpenAI.ChatCompletionMessageParam` type information.
 	 */
 	messages?: ChatMessage[]
+	/**
+	 * Enforces the response format to 'text' or 'JSON'.
+	 *
+	 * When the format is `text`, the model generates a string of text.
+	 *
+	 * When the format is `JSON`:
+	 * - Enables JSON mode which constrains the model to only generate strings that parse into a valid JSON object.
+	 * - Adds 'Return JSON' to an initial system message to avoid the API returning an error.
+	 * @link https://platform.openai.com/docs/guides/text-generation/json-mode OpenAI JSON mode
+	 */
+	format?: 'text' | 'JSON'
 }
 
 export type PromptResponseBody = string

--- a/packages/fullstack-components/src/handlers/prompt/promptClient.ts
+++ b/packages/fullstack-components/src/handlers/prompt/promptClient.ts
@@ -24,6 +24,13 @@ export async function getPrompt(
 	console.log('handling `getPrompt` request', request)
 	const messages: ChatMessage[] = []
 
+	if (request.format === 'JSON') {
+		messages.push({
+			role: 'system',
+			content: 'Return JSON',
+		})
+	}
+
 	if (request.messages) {
 		messages.push(...request.messages)
 	}
@@ -37,6 +44,7 @@ export async function getPrompt(
 
 	return await runChatCompletion(messages, {
 		openAIApiKey: options?.openAiApiKey || OPENAI_API_KEY,
+		format: request.format,
 	})
 }
 

--- a/packages/fullstack-components/src/handlers/prompt/promptHandler.ts
+++ b/packages/fullstack-components/src/handlers/prompt/promptHandler.ts
@@ -56,7 +56,11 @@ const appRouteHandlerFactory: (
 			console.log('requestBody', requestBody)
 			const gptResponse = await client.handle(requestBody, options)
 
-			return NextResponse.json(gptResponse.responseText, res)
+			if (requestBody.format === 'JSON') {
+				return NextResponse.json(JSON.parse(gptResponse.responseText), res)
+			} else {
+				return NextResponse.json(gptResponse.responseText, res)
+			}
 		} catch (error) {
 			throw new PromptError(error)
 		}
@@ -83,8 +87,13 @@ const pageRouteHandlerFactory: (
 			console.log('Prompt PAGES RouteHandlerFactory')
 			res.setHeader('Cache-Control', 'no-store')
 			const requestBody = req.body as PromptRequestBody
-			const parsedError = await client.handle(requestBody, options)
-			res.json(JSON.parse(parsedError.responseText))
+			const gptResponse = await client.handle(requestBody, options)
+
+			if (requestBody.format === 'JSON') {
+				res.json(JSON.parse(gptResponse.responseText))
+			} else {
+				res.json(gptResponse.responseText)
+			}
 		} catch (error) {
 			throw new PromptError(error)
 		}

--- a/packages/fullstack-components/src/handlers/prompt/usePrompt.ts
+++ b/packages/fullstack-components/src/handlers/prompt/usePrompt.ts
@@ -11,18 +11,30 @@ import { ApiUrlEnum } from '../../enums/ApiUrlEnum'
  * A client-side fetch handler hook that answers a `prompt` or an array of `messages` and returns the response as-is.
  * @see `ApiUrlEnum.prompt`
  */
-export function usePrompt(
+export function usePrompt<T = PromptResponseBody>(
 	/**
 	 * @link PromptRequestBody
 	 */
-	body: PromptRequestBody,
+	body: PromptRequestBody & { format?: 'text' | null },
 	/**
 	 * Fetch utility hook request options without the `fetcher`. Allows for overriding the default `request` config.
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
 	 */
 	config?: UseRequestConsumerConfig<PromptRequestBody>
+): ReturnType<typeof useRequest<T, PromptRequestBody>>
+export function usePrompt<
+	T = {
+		[k: string]: unknown
+	},
+>(
+	body: PromptRequestBody & { format: 'JSON' },
+	config?: UseRequestConsumerConfig<PromptRequestBody>
+): ReturnType<typeof useRequest<T, PromptRequestBody>>
+export function usePrompt<T = PromptResponseBody>(
+	body: PromptRequestBody,
+	config?: UseRequestConsumerConfig<PromptRequestBody>
 ) {
-	return useRequest<PromptResponseBody>(ApiUrlEnum.prompt, {
+	return useRequest<T>(ApiUrlEnum.prompt, {
 		body,
 		...config,
 	})

--- a/packages/site/src/app/docs/prompt/UsePrompt.tsx
+++ b/packages/site/src/app/docs/prompt/UsePrompt.tsx
@@ -5,11 +5,12 @@ import { usePrompt } from '@trikinco/fullstack-components/client'
 export default function Page() {
 	const { isLoading, data } = usePrompt({
 		prompt: 'What is the longest river in the world?',
+		format: 'JSON',
 	})
 
 	if (isLoading) {
 		return 'Loading...'
 	}
 
-	return <div className="max-w-prose">{data}</div>
+	return <div className="max-w-prose">{JSON.stringify(data)}</div>
 }

--- a/packages/site/src/app/docs/prompt/page.mdx
+++ b/packages/site/src/app/docs/prompt/page.mdx
@@ -1,5 +1,6 @@
 import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
 import { Prompt } from '@trikinco/fullstack-components'
+import UsePrompt from './UsePrompt'
 import { Example } from '@/src/components/Example'
 import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
@@ -78,28 +79,38 @@ The response can be wrapped in an element by using the `as` prop.
 In addition, this allows you to pass in any of the standard HTML attributes as expected by that element type.
 
 <Example>
-  <Prompt prompt="How big is the moon?" as="div" />
+  <Prompt
+    prompt="How big is the moon?"
+    as="h3"
+    className="text-xl"
+  />
 </Example>
 
 ```jsx /as="div"/
 <Prompt
   prompt="How big is the moon?"
-  as="div"
-  className="rounded-md overflow-hidden p-6 bg-sky-200 text-sky-800 text-xl"
+  as="h3"
+  className="text-xl"
 />
 ```
 
 ## `usePrompt` hook
 
-`usePrompt` is a utility hook that allows for full access to the same features as `Prompt`.
+`usePrompt` is a utility hook that allows for full access to the same features as `Prompt`, in addition to the ability to enable JSON mode with the `format` option.
+
+<Example>
+  <UsePrompt />
+</Example>
 
 ```jsx
 'use client'
-
 import { usePrompt } from '@trikinco/fullstack-components/client'
 
 export default function Page() {
   const { isLoading, data } = usePrompt({
+    // Enable JSON mode
+    format: 'JSON',
+    // Prompt. You can also define the desired response JSON schema here.
     prompt: 'What is the longest river in the world?',
   })
 
@@ -107,7 +118,7 @@ export default function Page() {
     return 'Loading...'
   }
 
-  return <div className="max-w-prose">{data}</div>
+  return <div className="max-w-prose">{JSON.stringify(data)}</div>
 }
 ```
 


### PR DESCRIPTION
- Updates prompt docs examples for `as` and `format`