### PR TITLE
chore: Ensures docs type information is available for search indexation

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -5,7 +5,7 @@
 	"private": true,
 	"scripts": {
 		"dev": "next dev",
-		"build": "node scripts/search.js && next build --debug && next-sitemap",
+		"build": "tsx scripts/search.mjs && next build --debug && next-sitemap",
 		"start": "next start",
 		"lint": "next lint",
 		"test:e2e": "playwright test",
@@ -43,6 +43,7 @@
 		"rehype-stringify": "10.0.0",
 		"rehype-toc": "3.0.2",
 		"remark-gfm": "4.0.0",
+		"remark-mdx": "3.0.0",
 		"remark-parse": "11.0.0",
 		"remark-rehype": "11.0.0",
 		"shiki": "0.14.5",
@@ -82,6 +83,7 @@
 		"prettier": "3.1.1",
 		"storybook": "7.5.2",
 		"tailwindcss": "3.4.0",
+		"tsx": "4.7.0",
 		"typescript": "5.2.2"
 	}
 }

--- a/packages/site/src/app/examples/DemoHTMLPage.tsx
+++ b/packages/site/src/app/examples/DemoHTMLPage.tsx
@@ -3,7 +3,7 @@
 import { useRef, type HTMLAttributes } from 'react'
 import { useFormState, useFormStatus } from 'react-dom'
 import { merge } from '@trikinco/fullstack-components/utils'
-import { generateHtmlPage } from '../docs/html-page-generator/action'
+import { generateHtmlPage } from '@/src/app/docs/html-page-generator/action'
 import { Button } from '@/src/components/Elements/Button'
 import { Input } from '@/src/components/Elements/Input'
 import { Label } from '@/src/components/Elements/Label'

--- a/packages/site/src/components/Accordion.tsx
+++ b/packages/site/src/components/Accordion.tsx
@@ -90,3 +90,5 @@ export const Accordion = ({
 		</details>
 	)
 }
+
+export default Accordion

--- a/packages/site/src/components/Avatar.tsx
+++ b/packages/site/src/components/Avatar.tsx
@@ -49,3 +49,5 @@ export const Avatar = ({
 		</Link>
 	)
 }
+
+export default Avatar

--- a/packages/site/src/components/ButtonCopy.tsx
+++ b/packages/site/src/components/ButtonCopy.tsx
@@ -45,3 +45,5 @@ export const ButtonCopy = ({ className, text, ...rest }: ButtonCopyProps) => {
 		</button>
 	)
 }
+
+export default ButtonCopy

--- a/packages/site/src/components/Card.tsx
+++ b/packages/site/src/components/Card.tsx
@@ -75,3 +75,5 @@ export const Card = <C extends ElementType = typeof defaultElement>({
 		</Component>
 	)
 }
+
+export default Card

--- a/packages/site/src/components/Chip.tsx
+++ b/packages/site/src/components/Chip.tsx
@@ -18,3 +18,5 @@ export const Chip = ({ children, className, ...rest }: ChipProps) => {
 		</div>
 	)
 }
+
+export default Chip

--- a/packages/site/src/components/CodeBlock.tsx
+++ b/packages/site/src/components/CodeBlock.tsx
@@ -43,3 +43,5 @@ export const CodeBlock = ({
 		</div>
 	)
 }
+
+export default CodeBlock

--- a/packages/site/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/site/src/components/ColorPicker/ColorPicker.tsx
@@ -182,3 +182,5 @@ export const ColorPicker = ({
 		</div>
 	)
 }
+
+export default ColorPicker

--- a/packages/site/src/components/ColorPicker/ColorPickerButton.tsx
+++ b/packages/site/src/components/ColorPicker/ColorPickerButton.tsx
@@ -52,3 +52,5 @@ export const ColorPickerButton = ({
 		</div>
 	)
 }
+
+export default ColorPickerButton

--- a/packages/site/src/components/ColorPicker/ColorPickerDialog.tsx
+++ b/packages/site/src/components/ColorPicker/ColorPickerDialog.tsx
@@ -121,3 +121,5 @@ export const ColorPickerDialog = memo(function ColorPickerDialog({
 		</Suspense>
 	)
 })
+
+export default ColorPickerDialog

--- a/packages/site/src/components/DialogBase.tsx
+++ b/packages/site/src/components/DialogBase.tsx
@@ -24,3 +24,5 @@ export const DialogBase = ({ children, ...rest }: DialogBaseProps) => {
 		</div>
 	)
 }
+
+export default DialogBase

--- a/packages/site/src/components/Elements/Button.tsx
+++ b/packages/site/src/components/Elements/Button.tsx
@@ -39,3 +39,5 @@ export const Button = <C extends ElementType = typeof defaultElement>({
 		</Component>
 	)
 }
+
+export default Button

--- a/packages/site/src/components/Example.tsx
+++ b/packages/site/src/components/Example.tsx
@@ -41,3 +41,5 @@ export const Example = <C extends ElementType = typeof defaultElement>({
 		</div>
 	)
 }
+
+export default Example

--- a/packages/site/src/components/Footer.tsx
+++ b/packages/site/src/components/Footer.tsx
@@ -110,3 +110,5 @@ export const Footer = ({ children, className, ...rest }: FooterProps) => {
 		</>
 	)
 }
+
+export default Footer

--- a/packages/site/src/components/Nav.tsx
+++ b/packages/site/src/components/Nav.tsx
@@ -57,3 +57,5 @@ export const Nav = ({ children, className, ...rest }: NavProps) => {
 		</nav>
 	)
 }
+
+export default Nav

--- a/packages/site/src/components/PageHeader.tsx
+++ b/packages/site/src/components/PageHeader.tsx
@@ -28,3 +28,5 @@ export const PageHeader = ({
 		</header>
 	)
 }
+
+export default PageHeader

--- a/packages/site/src/components/Prose.tsx
+++ b/packages/site/src/components/Prose.tsx
@@ -8,7 +8,7 @@ export interface ProseProps extends HTMLAttributes<HTMLDivElement> {
 
 export const defaultElement = 'div'
 
-export default function Prose<C extends ElementType = typeof defaultElement>({
+export function Prose<C extends ElementType = typeof defaultElement>({
 	as,
 	children,
 	className,
@@ -28,3 +28,5 @@ export default function Prose<C extends ElementType = typeof defaultElement>({
 		</Component>
 	)
 }
+
+export default Prose

--- a/packages/site/src/components/SkipLink.tsx
+++ b/packages/site/src/components/SkipLink.tsx
@@ -13,14 +13,12 @@ export interface SkipLinkProps
  * Skip link to jump past repetetive content
  * Uses `<a>` as `Link` from 'next/link' doesn't handle focus correctly for internal/fragment links
  */
-export default function SkipLink({
-	children,
-	className,
-	...rest
-}: SkipLinkProps) {
+export function SkipLink({ children, className, ...rest }: SkipLinkProps) {
 	return (
 		<a className={merge('sr-only focus:not-sr-only', className)} {...rest}>
 			{children}
 		</a>
 	)
 }
+
+export default SkipLink

--- a/packages/site/src/components/Slider.tsx
+++ b/packages/site/src/components/Slider.tsx
@@ -84,3 +84,5 @@ export const Slider = ({
 		</>
 	)
 }
+
+export default Slider

--- a/packages/site/src/components/Spinner.tsx
+++ b/packages/site/src/components/Spinner.tsx
@@ -42,3 +42,5 @@ export const Spinner = ({
 		</div>
 	)
 }
+
+export default Spinner

--- a/packages/site/src/components/Tab.tsx
+++ b/packages/site/src/components/Tab.tsx
@@ -74,3 +74,5 @@ export const Tab = ({
 		</button>
 	)
 }
+
+export default Tab

--- a/packages/site/src/components/Tabs.tsx
+++ b/packages/site/src/components/Tabs.tsx
@@ -160,3 +160,5 @@ export const Tabs = ({
 		</div>
 	)
 }
+
+export default Tabs

--- a/packages/site/src/components/TextRewriteControls.tsx
+++ b/packages/site/src/components/TextRewriteControls.tsx
@@ -69,3 +69,5 @@ export const TextRewriteControls = ({
 		</>
 	)
 }
+
+export default TextRewriteControls

--- a/packages/site/src/components/TypeInfo/TypeInfo.tsx
+++ b/packages/site/src/components/TypeInfo/TypeInfo.tsx
@@ -145,3 +145,5 @@ export const TypeInfo = ({
 		</div>
 	)
 }
+
+export default TypeInfo

--- a/packages/site/src/components/TypeInfo/TypeInfoTags.tsx
+++ b/packages/site/src/components/TypeInfo/TypeInfoTags.tsx
@@ -54,3 +54,5 @@ export const TypeInfoTags = ({
 		</div>
 	)
 }
+
+export default TypeInfoTags

--- a/packages/site/src/components/TypeInfo/TypeInfoTitle.tsx
+++ b/packages/site/src/components/TypeInfo/TypeInfoTitle.tsx
@@ -69,3 +69,5 @@ export const TypeInfoTitle = <C extends ElementType = typeof defaultElement>({
 		</TitleComponent>
 	)
 }
+
+export default TypeInfoTitle

--- a/packages/site/src/components/TypeInfo/TypeInfoToText.tsx
+++ b/packages/site/src/components/TypeInfo/TypeInfoToText.tsx
@@ -35,7 +35,7 @@ export interface TypeInfoToTextProps
 /**
  * Extracts type information from a .d.ts file with `getTypeDocs` and renders it
  */
-export const TypeInfoToText = async ({
+export const TypeInfoToText = ({
 	basePath = '../fullstack-components/dist/',
 	path: filePath,
 	name,
@@ -48,10 +48,7 @@ export const TypeInfoToText = async ({
 	...rest
 }: TypeInfoToTextProps) => {
 	const path = basePath + filePath
-	const { properties, parameters, returns, ...schema } = await getTypeDocs(
-		path,
-		name
-	)
+	const { properties, parameters, returns, ...schema } = getTypeDocs(path, name)
 	const hasParameters = parameters && parameters?.length > 0
 
 	return (
@@ -69,7 +66,7 @@ export const TypeInfoToText = async ({
 				returns={returns}
 				className="border-t-0"
 				component="h4"
-				id={name}
+				id={name.toLowerCase()}
 			>
 				{children}
 			</TypeInfo>
@@ -101,3 +98,5 @@ export const TypeInfoToText = async ({
 		</div>
 	)
 }
+
+export default TypeInfoToText

--- a/packages/site/src/utils/getTypeDocs.ts
+++ b/packages/site/src/utils/getTypeDocs.ts
@@ -207,10 +207,10 @@ const getExtractedTypeInfo = (
 /**
  * Extracts type info from a d.ts file
  */
-export async function getTypeDocs(
+export function getTypeDocs(
 	filePath: string,
 	typeName: string
-): Promise<ExtractedTypeInfo> {
+): ExtractedTypeInfo {
 	const files = [filePath]
 	const linker = createLinker(files)
 	const schema = linker.flatten(files[0], typeName)
@@ -218,3 +218,5 @@ export async function getTypeDocs(
 
 	return data
 }
+
+export default getTypeDocs

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       remark-gfm:
         specifier: 4.0.0
         version: 4.0.0
+      remark-mdx:
+        specifier: 3.0.0
+        version: 3.0.0
       remark-parse:
         specifier: 11.0.0
         version: 11.0.0
@@ -319,6 +322,9 @@ importers:
       tailwindcss:
         specifier: 3.4.0
         version: 3.4.0
+      tsx:
+        specifier: 4.7.0
+        version: 4.7.0
       typescript:
         specifier: 5.2.2
         version: 5.2.2
@@ -2024,12 +2030,30 @@ packages:
       jsdoc-type-pratt-parser: 4.0.0
     dev: true
 
+  /@esbuild/aix-ppc64@0.19.11:
+    resolution: {integrity: sha512-FnzU0LyE3ySQk7UntJO4+qIiQgI7KoODnZg5xzXIrFJlKd2P2gwHsHY4927xj9y5PJmJSzULiUCWmv7iWnNa7g==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm64@0.18.20:
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/android-arm64@0.19.11:
+    resolution: {integrity: sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm@0.18.20:
@@ -2040,12 +2064,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/android-arm@0.19.11:
+    resolution: {integrity: sha512-5OVapq0ClabvKvQ58Bws8+wkLCV+Rxg7tUVbo9xu034Nm536QTII4YzhaFriQ7rMrorfnFKUsArD2lqKbFY4vw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-x64@0.18.20:
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/android-x64@0.19.11:
+    resolution: {integrity: sha512-eccxjlfGw43WYoY9QgB82SgGgDbibcqyDTlk3l3C0jOVHKxrjdc9CTwDUQd0vkvYg5um0OH+GpxYvp39r+IPOg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.18.20:
@@ -2056,12 +2098,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.19.11:
+    resolution: {integrity: sha512-ETp87DRWuSt9KdDVkqSoKoLFHYTrkyz2+65fj9nfXsaV3bMhTCjtQfw3y+um88vGRKRiF7erPrh/ZuIdLUIVxQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-x64@0.18.20:
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.19.11:
+    resolution: {integrity: sha512-fkFUiS6IUK9WYUO/+22omwetaSNl5/A8giXvQlcinLIjVkxwTLSktbF5f/kJMftM2MJp9+fXqZ5ezS7+SALp4g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.18.20:
@@ -2072,12 +2132,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.19.11:
+    resolution: {integrity: sha512-lhoSp5K6bxKRNdXUtHoNc5HhbXVCS8V0iZmDvyWvYq9S5WSfTIHU2UGjcGt7UeS6iEYp9eeymIl5mJBn0yiuxA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-x64@0.18.20:
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.19.11:
+    resolution: {integrity: sha512-JkUqn44AffGXitVI6/AbQdoYAq0TEullFdqcMY/PCUZ36xJ9ZJRtQabzMA+Vi7r78+25ZIBosLTOKnUXBSi1Kw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.18.20:
@@ -2088,12 +2166,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-arm64@0.19.11:
+    resolution: {integrity: sha512-LneLg3ypEeveBSMuoa0kwMpCGmpu8XQUh+mL8XXwoYZ6Be2qBnVtcDI5azSvh7vioMDhoJFZzp9GWp9IWpYoUg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm@0.18.20:
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-arm@0.19.11:
+    resolution: {integrity: sha512-3CRkr9+vCV2XJbjwgzjPtO8T0SZUmRZla+UL1jw+XqHZPkPgZiyWvbDvl9rqAN8Zl7qJF0O/9ycMtjU67HN9/Q==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.18.20:
@@ -2104,12 +2200,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-ia32@0.19.11:
+    resolution: {integrity: sha512-caHy++CsD8Bgq2V5CodbJjFPEiDPq8JJmBdeyZ8GWVQMjRD0sU548nNdwPNvKjVpamYYVL40AORekgfIubwHoA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-loong64@0.18.20:
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.19.11:
+    resolution: {integrity: sha512-ppZSSLVpPrwHccvC6nQVZaSHlFsvCQyjnvirnVjbKSHuE5N24Yl8F3UwYUUR1UEPaFObGD2tSvVKbvR+uT1Nrg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.18.20:
@@ -2120,12 +2234,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.19.11:
+    resolution: {integrity: sha512-B5x9j0OgjG+v1dF2DkH34lr+7Gmv0kzX6/V0afF41FkPMMqaQ77pH7CrhWeR22aEeHKaeZVtZ6yFwlxOKPVFyg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ppc64@0.18.20:
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.19.11:
+    resolution: {integrity: sha512-MHrZYLeCG8vXblMetWyttkdVRjQlQUb/oMgBNurVEnhj4YWOr4G5lmBfZjHYQHHN0g6yDmCAQRR8MUHldvvRDA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.18.20:
@@ -2136,12 +2268,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.19.11:
+    resolution: {integrity: sha512-f3DY++t94uVg141dozDu4CCUkYW+09rWtaWfnb3bqe4w5NqmZd6nPVBm+qbz7WaHZCoqXqHz5p6CM6qv3qnSSQ==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-s390x@0.18.20:
     resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.19.11:
+    resolution: {integrity: sha512-A5xdUoyWJHMMlcSMcPGVLzYzpcY8QP1RtYzX5/bS4dvjBGVxdhuiYyFwp7z74ocV7WDc0n1harxmpq2ePOjI0Q==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.18.20:
@@ -2152,12 +2302,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-x64@0.19.11:
+    resolution: {integrity: sha512-grbyMlVCvJSfxFQUndw5mCtWs5LO1gUlwP4CDi4iJBbVpZcqLVT29FxgGuBJGSzyOxotFG4LoO5X+M1350zmPA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/netbsd-x64@0.18.20:
     resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.19.11:
+    resolution: {integrity: sha512-13jvrQZJc3P230OhU8xgwUnDeuC/9egsjTkXN49b3GcS5BKvJqZn86aGM8W9pd14Kd+u7HuFBMVtrNGhh6fHEQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.18.20:
@@ -2168,12 +2336,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/openbsd-x64@0.19.11:
+    resolution: {integrity: sha512-ysyOGZuTp6SNKPE11INDUeFVVQFrhcNDVUgSQVDzqsqX38DjhPEPATpid04LCoUr2WXhQTEZ8ct/EgJCUDpyNw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/sunos-x64@0.18.20:
     resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.19.11:
+    resolution: {integrity: sha512-Hf+Sad9nVwvtxy4DXCZQqLpgmRTQqyFyhT3bZ4F2XlJCjxGmRFF0Shwn9rzhOYRB61w9VMXUkxlBy56dk9JJiQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.18.20:
@@ -2184,6 +2370,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/win32-arm64@0.19.11:
+    resolution: {integrity: sha512-0P58Sbi0LctOMOQbpEOvOL44Ne0sqbS0XWHMvvrg6NE5jQ1xguCSSw9jQeUk2lfrXYsKDdOe6K+oZiwKPilYPQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-ia32@0.18.20:
     resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
     engines: {node: '>=12'}
@@ -2192,12 +2387,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/win32-ia32@0.19.11:
+    resolution: {integrity: sha512-6YOrWS+sDJDmshdBIQU+Uoyh7pQKrdykdefC1avn76ss5c+RN6gut3LZA4E2cH5xUEp5/cA0+YxRaVtRAb0xBg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64@0.18.20:
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/win32-x64@0.19.11:
+    resolution: {integrity: sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.52.0):
@@ -8239,6 +8452,37 @@ packages:
       '@esbuild/win32-arm64': 0.18.20
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
+
+  /esbuild@0.19.11:
+    resolution: {integrity: sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.19.11
+      '@esbuild/android-arm': 0.19.11
+      '@esbuild/android-arm64': 0.19.11
+      '@esbuild/android-x64': 0.19.11
+      '@esbuild/darwin-arm64': 0.19.11
+      '@esbuild/darwin-x64': 0.19.11
+      '@esbuild/freebsd-arm64': 0.19.11
+      '@esbuild/freebsd-x64': 0.19.11
+      '@esbuild/linux-arm': 0.19.11
+      '@esbuild/linux-arm64': 0.19.11
+      '@esbuild/linux-ia32': 0.19.11
+      '@esbuild/linux-loong64': 0.19.11
+      '@esbuild/linux-mips64el': 0.19.11
+      '@esbuild/linux-ppc64': 0.19.11
+      '@esbuild/linux-riscv64': 0.19.11
+      '@esbuild/linux-s390x': 0.19.11
+      '@esbuild/linux-x64': 0.19.11
+      '@esbuild/netbsd-x64': 0.19.11
+      '@esbuild/openbsd-x64': 0.19.11
+      '@esbuild/sunos-x64': 0.19.11
+      '@esbuild/win32-arm64': 0.19.11
+      '@esbuild/win32-ia32': 0.19.11
+      '@esbuild/win32-x64': 0.19.11
+    dev: true
 
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -15624,6 +15868,17 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 5.2.2
+    dev: true
+
+  /tsx@4.7.0:
+    resolution: {integrity: sha512-I+t79RYPlEYlHn9a+KzwrvEwhJg35h/1zHsLC2JXvhC2mdynMv6Zxzvhv5EMV6VF5qJlLlkSnMVvdZV3PSIGcg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.19.11
+      get-tsconfig: 4.7.2
+    optionalDependencies:
+      fsevents: 2.3.3
     dev: true
 
   /tty-browserify@0.0.1:


### PR DESCRIPTION
- TypeInfoToText components were previously added raw to the pages.json file, now the title and descriptions are output as plain text. In the future, this can be enhanced with more type information if needed.
- Adds missing leading slash to search docs routes