### PR TITLE
chore(site): Make the Not Found Enhancer example lazy to allow for indexation due to incorrect 'Soft 404' reported

### DIFF
--- a/packages/site/src/app/docs/audio/page.mdx
+++ b/packages/site/src/app/docs/audio/page.mdx
@@ -1,5 +1,3 @@
-import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
-import { Example } from '@/src/components/Example'
 import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
 import { Audio, Transcript } from '@trikinco/fullstack-components'

--- a/packages/site/src/app/docs/block/page.mdx
+++ b/packages/site/src/app/docs/block/page.mdx
@@ -1,5 +1,3 @@
-import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
-import { Example } from '@/src/components/Example'
 import Blocks from './Blocks'
 import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'

--- a/packages/site/src/app/docs/error-enhancer/page.mdx
+++ b/packages/site/src/app/docs/error-enhancer/page.mdx
@@ -1,4 +1,3 @@
-import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
 import { ErrorHTTPPreview } from './ErrorHTTPPreview'
 import { ClientErrors } from './ClientErrors'
 import { URL_HOST } from '@/src/utils/constants'

--- a/packages/site/src/app/docs/html-page-generator/page.mdx
+++ b/packages/site/src/app/docs/html-page-generator/page.mdx
@@ -1,4 +1,3 @@
-import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
 import { Form } from './Form'
 import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'

--- a/packages/site/src/app/docs/image/page.mdx
+++ b/packages/site/src/app/docs/image/page.mdx
@@ -1,6 +1,4 @@
-import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
 import { Image } from '@trikinco/fullstack-components'
-import { Example } from '@/src/components/Example'
 import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
 

--- a/packages/site/src/app/docs/not-found-enhancer/page.mdx
+++ b/packages/site/src/app/docs/not-found-enhancer/page.mdx
@@ -1,5 +1,3 @@
-import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
-import { Example } from '@/src/components/Example'
 import { NotFoundEnhancer } from './NotFoundEnhancer'
 import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
@@ -24,7 +22,7 @@ The `useNotFoundEnhancement` hook is a React hook that can be used to fetch the 
 
 See [Usage](/docs/usage) for a full example on making your own `NotFoundEnhancer` component.
 
-<Example>
+<Example lazy>
   <NotFoundEnhancer />
 </Example>
 

--- a/packages/site/src/app/docs/prompt/page.mdx
+++ b/packages/site/src/app/docs/prompt/page.mdx
@@ -1,7 +1,5 @@
-import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
 import { Prompt } from '@trikinco/fullstack-components'
 import UsePrompt from './UsePrompt'
-import { Example } from '@/src/components/Example'
 import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
 

--- a/packages/site/src/app/docs/select/page.mdx
+++ b/packages/site/src/app/docs/select/page.mdx
@@ -1,6 +1,4 @@
-import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
 import { Select } from '@trikinco/fullstack-components'
-import { Example } from '@/src/components/Example'
 import UseSelect from './UseSelect'
 import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'

--- a/packages/site/src/app/docs/text/page.mdx
+++ b/packages/site/src/app/docs/text/page.mdx
@@ -1,6 +1,4 @@
-import { TypeInfoToText } from '@/src/components/TypeInfo/TypeInfoToText'
 import { Text } from '@trikinco/fullstack-components'
-import { Example } from '@/src/components/Example'
 import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
 

--- a/packages/site/src/components/Example.tsx
+++ b/packages/site/src/components/Example.tsx
@@ -1,11 +1,20 @@
-import type { HTMLAttributes, ReactNode, ElementType } from 'react'
+'use client'
+import {
+	useState,
+	type HTMLAttributes,
+	type ReactNode,
+	type ElementType,
+} from 'react'
 import type { AsComponent } from '@trikinco/fullstack-components'
 import { merge } from '@trikinco/fullstack-components/utils'
+import Button from '@/src/components/Elements/Button'
 
 export interface ExampleProps extends HTMLAttributes<HTMLDivElement> {
 	children?: ReactNode
 	/** Label above the example output. Default: 'Live Example' */
 	label?: string
+	/** `lazy` requires user interaction to render the children */
+	lazy?: boolean
 	/** removes the `not-prose` className on the wrapper style fonts as prose  */
 	isProse?: boolean
 }
@@ -18,11 +27,13 @@ export const defaultElement = 'div'
 export const Example = <C extends ElementType = typeof defaultElement>({
 	as,
 	label = 'Live Example',
+	lazy,
 	children,
 	isProse,
 	className,
 	...rest
 }: AsComponent<C, ExampleProps>) => {
+	const [shouldMount, setShouldMount] = useState(!lazy)
 	const Component = as || defaultElement
 
 	return (
@@ -36,7 +47,11 @@ export const Example = <C extends ElementType = typeof defaultElement>({
 				)}
 				{...rest}
 			>
-				{children}
+				{shouldMount ? (
+					children
+				) : (
+					<Button onClick={() => setShouldMount(true)}>Load example</Button>
+				)}
 			</Component>
 		</div>
 	)

--- a/packages/site/src/utils/markdown.ts
+++ b/packages/site/src/utils/markdown.ts
@@ -1,4 +1,6 @@
 import { CodeBlock } from '../components/CodeBlock'
+import { Example } from '../components/Example'
+import { TypeInfoToText } from '../components/TypeInfo/TypeInfoToText'
 
 /**
  * Default components to use for
@@ -6,4 +8,6 @@ import { CodeBlock } from '../components/CodeBlock'
  */
 export const defaultComponents = {
 	pre: CodeBlock,
+	Example,
+	TypeInfoToText,
 }


### PR DESCRIPTION
<img width="1582" alt="Screenshot 2024-01-07 at 21 12 47" src="https://github.com/trikinco/fullstack-components/assets/7847281/8d031a29-6914-45f5-99e1-3eecaf61f500">
