### PR TITLE
chore(site): HTML page generator code highlighting

### DIFF
--- a/packages/site/mdx-config.mjs
+++ b/packages/site/mdx-config.mjs
@@ -3,6 +3,7 @@ import rehypeSlug from 'rehype-slug'
 import rehypeAutolinkHeadings from 'rehype-autolink-headings'
 import rehypePrettyCode from 'rehype-pretty-code'
 import { visit } from 'unist-util-visit'
+import theme from './src/assets/themes/css-variables.json' assert { type: 'json' }
 
 /**
  * - remark-gfm to add support for GitHub Flavored Markdown
@@ -63,7 +64,8 @@ export const rehypePlugins = [
 		 * @see {@link https://github.com/shikijs/shiki/blob/main/docs/themes.md#theming-with-css-variables theming with CSS variables}
 		 */
 		{
-			theme: 'css-variables',
+			theme,
+			keepBackground: false,
 		},
 	],
 	/**

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -38,7 +38,7 @@
 		"react-error-boundary": "4.0.11",
 		"react-type-animation": "3.2.0",
 		"rehype-autolink-headings": "7.0.0",
-		"rehype-pretty-code": "0.11.0",
+		"rehype-pretty-code": "0.12.3",
 		"rehype-slug": "6.0.0",
 		"rehype-stringify": "10.0.0",
 		"rehype-toc": "3.0.2",
@@ -46,7 +46,7 @@
 		"remark-mdx": "3.0.0",
 		"remark-parse": "11.0.0",
 		"remark-rehype": "11.0.0",
-		"shiki": "0.14.5",
+		"shikiji": "0.9.17",
 		"unified": "11.0.4",
 		"unist-util-visit": "5.0.0"
 	},

--- a/packages/site/src/app/docs/audio/page.mdx
+++ b/packages/site/src/app/docs/audio/page.mdx
@@ -47,7 +47,7 @@ Creates an audio file from text `content` or a React tree. Also generates VTT ca
   </Audio>
 </Example>
 
-```jsx
+```tsx
 <Audio controls>
   <h2>Hey there my friend, how are you?</h2>
   <p>
@@ -78,7 +78,7 @@ Creates VTT captions from an audio file.
   <CenteredTrackCues />
 </Example>
 
-```jsx {12}
+```tsx {12}
 // Using a video element here
 // to visibly show the captions.
 // `Audio` Server Component already uses `Track`.
@@ -106,7 +106,7 @@ Transcribes an audio file to text.
   />
 </Example>
 
-```jsx
+```tsx
 <Transcript
   src="/my-super-original-podcast.mp3"
   as="p"
@@ -118,7 +118,7 @@ Transcribes an audio file to text.
 
 `useAudio` is a utility hook that allows for full access to the same features as `getAudio`, in addition to the ability to control the audio file playback.
 
-```jsx
+```tsx
 'use client'
 import { useAudio } from '@trikinco/fullstack-components/client'
 
@@ -235,7 +235,7 @@ export { fscHandler as GET, fscHandler as POST }
 
 <TypeInfoToText path="components/Audio.d.ts" name="Audio">
 
-```jsx
+```tsx
 import { Audio } from '@trikinco/fullstack-components'
 ```
 
@@ -245,7 +245,7 @@ import { Audio } from '@trikinco/fullstack-components'
 
 <TypeInfoToText path="components/Track.d.ts" name="Track">
 
-```jsx
+```tsx
 import { Track } from '@trikinco/fullstack-components'
 ```
 
@@ -261,7 +261,7 @@ import { Track } from '@trikinco/fullstack-components'
   name="Transcript"
 >
 
-```jsx
+```tsx
 import { Transcript } from '@trikinco/fullstack-components'
 ```
 
@@ -274,7 +274,7 @@ import { Transcript } from '@trikinco/fullstack-components'
   name="useAudio"
 >
 
-```jsx
+```tsx
 import { useAudio } from '@trikinco/fullstack-components/client'
 ```
 
@@ -285,7 +285,7 @@ import { useAudio } from '@trikinco/fullstack-components/client'
   name="useAudioSource"
 >
 
-```jsx
+```tsx
 import { useAudioSource } from '@trikinco/fullstack-components/client'
 ```
 
@@ -298,7 +298,7 @@ import { useAudioSource } from '@trikinco/fullstack-components/client'
   name="getAudio"
 >
 
-```jsx
+```tsx
 import { getAudio } from '@trikinco/fullstack-components'
 ```
 
@@ -309,7 +309,7 @@ import { getAudio } from '@trikinco/fullstack-components'
   name="fetchAudio"
 >
 
-```jsx
+```tsx
 import { fetchAudio } from '@trikinco/fullstack-components/client'
 ```
 

--- a/packages/site/src/app/docs/block/page.mdx
+++ b/packages/site/src/app/docs/block/page.mdx
@@ -21,7 +21,7 @@ Blocks are individual React components that are generated and mounted on the fly
   <Blocks />
 </Example>
 
-```jsx
+```tsx
 <Block
   prompt="A navbar with a modern SVG logo, the title 'myProject' and some links. Dark bg, light text."
   fallback={<p>Creating navbar component...</p>}
@@ -33,7 +33,7 @@ Blocks are individual React components that are generated and mounted on the fly
 
 `useBlock` is a utility hook that allows for access to similar features as `Block`.
 
-```jsx
+```tsx
 'use client'
 
 import { useBlock } from '@trikinco/fullstack-components/client'
@@ -102,7 +102,7 @@ export { fscHandler as GET, fscHandler as POST }
 
 <TypeInfoToText path="components/Block.d.ts" name="Block">
 
-```jsx
+```tsx
 import { Block } from '@trikinco/fullstack-components/client'
 ```
 
@@ -115,7 +115,7 @@ import { Block } from '@trikinco/fullstack-components/client'
   name="useBlock"
 >
 
-```jsx
+```tsx
 import { useBlock } from '@trikinco/fullstack-components/client'
 ```
 
@@ -128,7 +128,7 @@ import { useBlock } from '@trikinco/fullstack-components/client'
   name="getBlock"
 >
 
-```jsx
+```tsx
 import { getBlock } from '@trikinco/fullstack-components'
 ```
 
@@ -139,7 +139,7 @@ import { getBlock } from '@trikinco/fullstack-components'
   name="fetchBlock"
 >
 
-```jsx
+```tsx
 import { fetchBlock } from '@trikinco/fullstack-components/client'
 ```
 
@@ -150,7 +150,7 @@ import { fetchBlock } from '@trikinco/fullstack-components/client'
   name="fetchProcessedBlock"
 >
 
-```jsx
+```tsx
 import { fetchProcessedBlock } from '@trikinco/fullstack-components/client'
 ```
 

--- a/packages/site/src/app/docs/error-enhancer/page.mdx
+++ b/packages/site/src/app/docs/error-enhancer/page.mdx
@@ -18,7 +18,7 @@ These error enhancement tools can be used to show users a user-friendly message 
 
 ## `useErrorEnhancement` hook
 
-```jsx
+```tsx
 import { useErrorEnhancement } from '@trikinco/fullstack-components/client'
 ```
 
@@ -54,7 +54,7 @@ import { useErrorEnhancement } from '@trikinco/fullstack-components/client'
   label="Live Example · HTTP `503 Service Unavailable`"
 />
 
-```jsx title="Client Component"
+```tsx title="Client Component"
 'use client'
 
 import { useErrorEnhancement } from '@trikinco/fullstack-components/client'
@@ -83,7 +83,7 @@ export default function Page({ error }) {
 
 ## `ErrorEnhancementBoundary` Client Component
 
-```jsx
+```tsx
 import { ErrorEnhancementBoundary } from '@trikinco/fullstack-components/client'
 ```
 
@@ -91,7 +91,7 @@ import { ErrorEnhancementBoundary } from '@trikinco/fullstack-components/client'
 
 <ClientErrors />
 
-```jsx title="Client Component"
+```tsx title="Client Component"
 'use client'
 
 import { ErrorEnhancementBoundary } from '@trikinco/fullstack-components/client'
@@ -180,7 +180,7 @@ export { fscHandler as GET, fscHandler as POST }
   name="ErrorEnhancementBoundary"
 >
 
-```jsx
+```tsx
 import { ErrorEnhancementBoundary } from '@trikinco/fullstack-components/client'
 ```
 
@@ -196,7 +196,7 @@ import { ErrorEnhancementBoundary } from '@trikinco/fullstack-components/client'
   name="ErrorEnhancementFallback"
 >
 
-```jsx
+```tsx
 import { ErrorEnhancementFallback } from '@trikinco/fullstack-components/client'
 ```
 
@@ -209,7 +209,7 @@ import { ErrorEnhancementFallback } from '@trikinco/fullstack-components/client'
   name="useErrorEnhancement"
 >
 
-```jsx
+```tsx
 import { useErrorEnhancement } from '@trikinco/fullstack-components/client'
 ```
 
@@ -222,7 +222,7 @@ import { useErrorEnhancement } from '@trikinco/fullstack-components/client'
   name="getErrorEnhancement"
 >
 
-```jsx
+```tsx
 import { getErrorEnhancement } from '@trikinco/fullstack-components'
 ```
 
@@ -233,7 +233,7 @@ import { getErrorEnhancement } from '@trikinco/fullstack-components'
   name="fetchErrorEnhancement"
 >
 
-```jsx
+```tsx
 import { fetchErrorEnhancement } from '@trikinco/fullstack-components/client'
 ```
 

--- a/packages/site/src/app/docs/html-page-generator/FormBody.tsx
+++ b/packages/site/src/app/docs/html-page-generator/FormBody.tsx
@@ -76,7 +76,11 @@ export function FormBody({ state, refetch }: FormBodyProps) {
 						{pending ? (
 							<>
 								Creating page{' '}
-								<IconLoader className="ml-2" width={20} height={20} />
+								<IconLoader
+									className="ml-2 animate-spin"
+									width={20}
+									height={20}
+								/>
 							</>
 						) : (
 							<>

--- a/packages/site/src/app/docs/html-page-generator/page.mdx
+++ b/packages/site/src/app/docs/html-page-generator/page.mdx
@@ -22,7 +22,7 @@ The below HTML page generator and preview is an example of the kinds of interfac
 
 ## `useHtmlPage` hook
 
-```jsx title="Client Component"
+```tsx title="Client Component"
 'use client'
 
 import { useHtmlPage } from '@trikinco/fullstack-components/client'
@@ -68,7 +68,7 @@ export default function Page() {
 
 ## Custom Server Component with `getHtmlPage`
 
-```jsx title="Server Component"
+```tsx title="Server Component"
 import { getHtmlPage } from '@trikinco/fullstack-components'
 
 export default async function Page() {
@@ -137,7 +137,7 @@ export { fscHandler as GET, fscHandler as POST }
   name="useHtmlPage"
 >
 
-```jsx
+```tsx
 import { useHtmlPage } from '@trikinco/fullstack-components/client'
 ```
 
@@ -150,7 +150,7 @@ import { useHtmlPage } from '@trikinco/fullstack-components/client'
   name="getHtmlPage"
 >
 
-```jsx
+```tsx
 import { getHtmlPage } from '@trikinco/fullstack-components'
 ```
 
@@ -161,7 +161,7 @@ import { getHtmlPage } from '@trikinco/fullstack-components'
   name="fetchHtmlPage"
 >
 
-```jsx
+```tsx
 import { fetchHtmlPage } from '@trikinco/fullstack-components/client'
 ```
 

--- a/packages/site/src/app/docs/image/page.mdx
+++ b/packages/site/src/app/docs/image/page.mdx
@@ -28,7 +28,7 @@ A smart image component that either describes a known image, generates an image 
   />
 </Example>
 
-```jsx
+```tsx
 <Image
   src="https://absolute-cat-url/tabbycat.jpg"
   showResult // Optional - to render the alt-text visually
@@ -47,7 +47,7 @@ A smart image component that either describes a known image, generates an image 
   />
 </Example>
 
-```jsx
+```tsx
 <Image
   prompt="A photograph of a cat wearing a cowboy hat"
   model="dall-e-3"
@@ -66,7 +66,7 @@ A smart image component that either describes a known image, generates an image 
   />
 </Example>
 
-```jsx
+```tsx
 <Image
   src="/images/MobiusStrip.png"
   alt="A white coiling mobius strip"
@@ -79,13 +79,13 @@ A smart image component that either describes a known image, generates an image 
 
 `useImage` is a utility hook that allows for full access to the same features as `Image`, in addition to being able to generate multiple images.
 
-```jsx
+```tsx
 import { useImage } from '@trikinco/fullstack-components/client'
 ```
 
 ### `useImage` image description with `src`
 
-```jsx
+```tsx
 'use client'
 
 import { useImage } from '@trikinco/fullstack-components/client'
@@ -113,7 +113,7 @@ export default function Page() {
 
 ### `useImage` image generation of multiple images with `prompt` and `n`
 
-```jsx
+```tsx
 'use client'
 
 import { useImage } from '@trikinco/fullstack-components/client'
@@ -144,7 +144,7 @@ export default function Page() {
 }
 ```
 
-```jsx title="Server Component"
+```tsx title="Server Component"
 import { getImage } from '@trikinco/fullstack-components'
 
 export default async function Page() {
@@ -234,7 +234,7 @@ export { fscHandler as GET, fscHandler as POST }
 
 <TypeInfoToText path="components/Image/Image.d.ts" name="Image">
 
-```jsx
+```tsx
 import { Image } from '@trikinco/fullstack-components'
 ```
 
@@ -247,7 +247,7 @@ import { Image } from '@trikinco/fullstack-components'
   name="useImage"
 >
 
-```jsx
+```tsx
 import { useImage } from '@trikinco/fullstack-components/client'
 ```
 
@@ -260,7 +260,7 @@ import { useImage } from '@trikinco/fullstack-components/client'
   name="getImage"
 >
 
-```jsx
+```tsx
 import { getImage } from '@trikinco/fullstack-components'
 ```
 
@@ -271,7 +271,7 @@ import { getImage } from '@trikinco/fullstack-components'
   name="getEnhancedImage"
 >
 
-```jsx
+```tsx
 import { getEnhancedImage } from '@trikinco/fullstack-components'
 ```
 
@@ -282,7 +282,7 @@ import { getEnhancedImage } from '@trikinco/fullstack-components'
   name="fetchImage"
 >
 
-```jsx
+```tsx
 import { fetchImage } from '@trikinco/fullstack-components/client'
 ```
 

--- a/packages/site/src/app/docs/not-found-enhancer/page.mdx
+++ b/packages/site/src/app/docs/not-found-enhancer/page.mdx
@@ -129,7 +129,7 @@ export { fscHandler as GET, fscHandler as POST }
   name="useNotFoundEnhancement"
 >
 
-```jsx
+```tsx
 import { useNotFoundEnhancement } from '@trikinco/fullstack-components/client'
 ```
 
@@ -142,7 +142,7 @@ import { useNotFoundEnhancement } from '@trikinco/fullstack-components/client'
   name="getNotFoundContentGenerator"
 >
 
-```jsx
+```tsx
 import { getNotFoundContentGenerator } from '@trikinco/fullstack-components'
 ```
 
@@ -153,7 +153,7 @@ import { getNotFoundContentGenerator } from '@trikinco/fullstack-components'
   name="getNotFoundSitemapSelector"
 >
 
-```jsx
+```tsx
 import { getNotFoundSitemapSelector } from '@trikinco/fullstack-components'
 ```
 
@@ -164,7 +164,7 @@ import { getNotFoundSitemapSelector } from '@trikinco/fullstack-components'
   name="fetchNotFoundEnhancement"
 >
 
-```jsx
+```tsx
 import { fetchNotFoundEnhancement } from '@trikinco/fullstack-components/client'
 ```
 

--- a/packages/site/src/app/docs/prompt/page.mdx
+++ b/packages/site/src/app/docs/prompt/page.mdx
@@ -25,7 +25,7 @@ They accept a text `prompt` and arrays of `messages` and return the data as-is.
   <Prompt prompt="What's the longest river in the world?" />
 </Example>
 
-```jsx
+```tsx
 <Prompt prompt="What's the longest river in the world?" />
 ```
 
@@ -47,7 +47,7 @@ They accept a text `prompt` and arrays of `messages` and return the data as-is.
   />
 </Example>
 
-```jsx
+```tsx
 <Prompt
   messages={[
     {
@@ -76,7 +76,7 @@ In addition, this allows you to pass in any of the standard HTML attributes as e
   />
 </Example>
 
-```jsx /as="div"/
+```tsx /as="div"/
 <Prompt
   prompt="How big is the moon?"
   as="h3"
@@ -92,7 +92,7 @@ In addition, this allows you to pass in any of the standard HTML attributes as e
   <UsePrompt />
 </Example>
 
-```jsx
+```tsx
 'use client'
 import { usePrompt } from '@trikinco/fullstack-components/client'
 
@@ -112,7 +112,7 @@ export default function Page() {
 }
 ```
 
-```jsx title="Server Component"
+```tsx title="Server Component"
 import { getPrompt } from '@trikinco/fullstack-components'
 
 export default async function Page() {

--- a/packages/site/src/app/docs/select/page.mdx
+++ b/packages/site/src/app/docs/select/page.mdx
@@ -24,7 +24,7 @@ A smart dropdown component that creates, labels and sorts all its own options.
     context="The time zone for Sydney should be selected"
   />
 </Example>
-```jsx
+```tsx
 <Select
   prompt="Selecting a time zone in GMT"
   context="The time zone for Sydney should be selected"
@@ -40,7 +40,7 @@ Useful for generating lists or when creating custom dropdown components.
   <UseSelect />
 </Example>
 
-```jsx
+```tsx
 'use client'
 
 import { useSelect } from '@trikinco/fullstack-components/client'
@@ -75,7 +75,7 @@ export default function Page() {
 
 ## Custom Server Component with `getSelect`
 
-```jsx title="Server Component"
+```tsx title="Server Component"
 import { getSelect } from '@trikinco/fullstack-components'
 
 export default async function Page() {
@@ -169,7 +169,7 @@ export { fscHandler as GET, fscHandler as POST }
 
 <TypeInfoToText path="components/Select.d.ts" name="Select" >
 
-```jsx
+```tsx
 import { Select } from '@trikinco/fullstack-components'
 ```
 
@@ -182,7 +182,7 @@ import { Select } from '@trikinco/fullstack-components'
   name="useSelect"
 >
 
-```jsx
+```tsx
 import { useSelect } from '@trikinco/fullstack-components/client'
 ```
 
@@ -195,7 +195,7 @@ import { useSelect } from '@trikinco/fullstack-components/client'
   name="getSelect"
 >
 
-```jsx
+```tsx
 import { getSelect } from '@trikinco/fullstack-components'
 ```
 
@@ -206,7 +206,7 @@ import { getSelect } from '@trikinco/fullstack-components'
   name="fetchSelect"
 >
 
-```jsx
+```tsx
 import { fetchSelect } from '@trikinco/fullstack-components/client'
 ```
 

--- a/packages/site/src/app/docs/text/page.mdx
+++ b/packages/site/src/app/docs/text/page.mdx
@@ -45,7 +45,7 @@ Rewrite, simplify or create text. Handles plain text, markdown and HTML.
 </Text>
 </Example>
 
-```jsx title="Text rewrite example"
+```tsx title="Text rewrite example"
 <Text
   prompt="Summarize to one or two short paragraphs"
   grade={5}
@@ -88,7 +88,7 @@ Rewrite, simplify or create text. Handles plain text, markdown and HTML.
   </Text>
 </Example>
 
-```jsx title="Text creation example"
+```tsx title="Text creation example"
 <Text
   prompt="Write a poem"
   grade={5}
@@ -102,7 +102,7 @@ Rewrite, simplify or create text. Handles plain text, markdown and HTML.
 
 ## `useText` hook
 
-```jsx
+```tsx
 'use client'
 
 import { useText } from '@trikinco/fullstack-components/client'
@@ -132,7 +132,7 @@ export default function Page() {
 
 `useText` also accepts a tree of components in `content`. Note that only static HTML is returned.
 
-```jsx title="useText with HTML"
+```tsx title="useText with HTML"
 const { isLoading, data } = useText({
   prompt: 'Simplify and shorten this text',
   content: (
@@ -150,7 +150,7 @@ const { isLoading, data } = useText({
 })
 ```
 
-```jsx title="Server Component"
+```tsx title="Server Component"
 import { getText } from '@trikinco/fullstack-components'
 
 export default async function Page() {

--- a/packages/site/src/app/examples/DemoHTMLPage.tsx
+++ b/packages/site/src/app/examples/DemoHTMLPage.tsx
@@ -41,7 +41,7 @@ export function FormBody({ state }: FormBodyProps) {
 								What do you want to create? ✨
 							</Label>
 							<Input
-								className="border border-gray-200 dark:bg-white dark:text-black"
+								className="border border-gray-200 dark:border-gray-200 dark:bg-white dark:text-black"
 								id="prompt"
 								name="prompt"
 								placeholder="A modern login form..."

--- a/packages/site/src/app/examples/DemoSelect.tsx
+++ b/packages/site/src/app/examples/DemoSelect.tsx
@@ -49,7 +49,7 @@ export default function Page() {
 					Your name
 				</Label>
 				<Input
-					className="border border-gray-200 dark:bg-white dark:text-black"
+					className="border border-gray-200 dark:border-gray-200 dark:bg-white dark:text-black"
 					id="name"
 					name="name"
 					minLength={1}

--- a/packages/site/src/assets/themes/css-variables.json
+++ b/packages/site/src/assets/themes/css-variables.json
@@ -1,0 +1,189 @@
+{
+	"name": "css-variables",
+	"type": "css",
+	"colors": {
+		"editor.foreground": "var(--shiki-color-text)",
+		"editor.background": "var(--shiki-color-background)",
+		"terminal.ansiBlack": "var(--shiki-color-text)",
+		"terminal.ansiRed": "var(--shiki-color-text)",
+		"terminal.ansiGreen": "var(--shiki-color-text)",
+		"terminal.ansiYellow": "var(--shiki-color-text)",
+		"terminal.ansiBlue": "var(--shiki-color-text)",
+		"terminal.ansiMagenta": "var(--shiki-color-text)",
+		"terminal.ansiCyan": "var(--shiki-color-text)",
+		"terminal.ansiWhite": "var(--shiki-color-text)",
+		"terminal.ansiBrightBlack": "var(--shiki-color-text)",
+		"terminal.ansiBrightRed": "var(--shiki-color-text)",
+		"terminal.ansiBrightGreen": "var(--shiki-color-text)",
+		"terminal.ansiBrightYellow": "var(--shiki-color-text)",
+		"terminal.ansiBrightBlue": "var(--shiki-color-text)",
+		"terminal.ansiBrightMagenta": "var(--shiki-color-text)",
+		"terminal.ansiBrightCyan": "var(--shiki-color-text)",
+		"terminal.ansiBrightWhite": "var(--shiki-color-text)"
+	},
+	"tokenColors": [
+		{
+			"settings": {
+				"foreground": "var(--shiki-color-text)"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.accessor",
+				"meta.group.braces.round.function.arguments",
+				"meta.template.expression",
+				"markup.fenced_code meta.embedded.block"
+			],
+			"settings": {
+				"foreground": "var(--shiki-color-text)"
+			}
+		},
+		{
+			"scope": "emphasis",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": ["strong", "markup.heading.markdown", "markup.bold.markdown"],
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"scope": ["markup.italic.markdown"],
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": "meta.link.inline.markdown",
+			"settings": {
+				"fontStyle": "underline",
+				"foreground": "var(--shiki-token-link)"
+			}
+		},
+		{
+			"scope": ["string", "markup.fenced_code", "markup.inline"],
+			"settings": {
+				"foreground": "var(--shiki-token-link)"
+			}
+		},
+		{
+			"scope": ["comment", "string.quoted.docstring.multi"],
+			"settings": {
+				"foreground": "var(--shiki-token-comment)"
+			}
+		},
+		{
+			"scope": [
+				"constant.numeric",
+				"constant.language",
+				"constant.other.placeholder",
+				"constant.character.format.placeholder",
+				"variable.language.this",
+				"variable.other.object",
+				"variable.other.class",
+				"variable.other.constant",
+				"meta.property-name",
+				"meta.property-value",
+				"support"
+			],
+			"settings": {
+				"foreground": "var(--shiki-token-constant)"
+			}
+		},
+		{
+			"scope": [
+				"keyword",
+				"storage.modifier",
+				"storage.type",
+				"storage.control.clojure",
+				"entity.name.function.clojure",
+				"entity.name.tag.yaml",
+				"support.function.node",
+				"support.type.property-name.json",
+				"punctuation.separator.key-value",
+				"punctuation.definition.template-expression"
+			],
+			"settings": {
+				"foreground": "var(--shiki-token-keyword)"
+			}
+		},
+		{
+			"scope": "variable.parameter.function",
+			"settings": {
+				"foreground": "var(--shiki-token-parameter)"
+			}
+		},
+		{
+			"scope": [
+				"support.function",
+				"entity.name.type",
+				"entity.other.inherited-class",
+				"meta.function-call",
+				"meta.instance.constructor",
+				"entity.other.attribute-name",
+				"entity.name.function",
+				"constant.keyword.clojure"
+			],
+			"settings": {
+				"foreground": "var(--shiki-token-function)"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.tag",
+				"string.quoted",
+				"string.regexp",
+				"string.interpolated",
+				"string.template",
+				"string.unquoted.plain.out.yaml",
+				"keyword.other.template"
+			],
+			"settings": {
+				"foreground": "var(--shiki-token-string-expression)"
+			}
+		},
+		{
+			"scope": [
+				"punctuation.definition.arguments",
+				"punctuation.definition.dict",
+				"punctuation.separator",
+				"meta.function-call.arguments"
+			],
+			"settings": {
+				"foreground": "var(--shiki-token-punctuation)"
+			}
+		},
+		{
+			"name": "[Custom] Markdown links",
+			"scope": [
+				"markup.underline.link",
+				"punctuation.definition.metadata.markdown"
+			],
+			"settings": {
+				"foreground": "var(--shiki-token-link)"
+			}
+		},
+		{
+			"name": "[Custom] Markdown list",
+			"scope": ["beginning.punctuation.definition.list.markdown"],
+			"settings": {
+				"foreground": "var(--shiki-token-punctuation)"
+			}
+		},
+		{
+			"name": "[Custom] Markdown punctuation definition brackets",
+			"scope": [
+				"punctuation.definition.string.begin.markdown",
+				"punctuation.definition.string.end.markdown",
+				"string.other.link.title.markdown",
+				"string.other.link.description.markdown"
+			],
+			"settings": {
+				"foreground": "var(--shiki-token-punctuation)"
+			}
+		}
+	]
+}

--- a/packages/site/src/components/ButtonCopy.tsx
+++ b/packages/site/src/components/ButtonCopy.tsx
@@ -34,6 +34,7 @@ export const ButtonCopy = ({ className, text, ...rest }: ButtonCopyProps) => {
 			disabled={isCopied}
 			aria-label={label}
 			onClick={copy}
+			type="button"
 			{...rest}
 		>
 			{isCopied ? (

--- a/packages/site/src/components/Code.tsx
+++ b/packages/site/src/components/Code.tsx
@@ -2,7 +2,7 @@ import type { HTMLAttributes, ReactNode } from 'react'
 import { ButtonCopy } from './ButtonCopy'
 import { merge } from '@trikinco/fullstack-components/utils'
 
-export interface CodeBlockProps extends HTMLAttributes<HTMLPreElement> {
+export interface CodeProps extends HTMLAttributes<HTMLPreElement> {
 	children?: ReactNode
 	/** raw node contents */
 	raw?: string
@@ -14,18 +14,21 @@ export interface CodeBlockProps extends HTMLAttributes<HTMLPreElement> {
  * Markdown code block with a copy button
  * @see `next.config` for custom rehype setup for this
  */
-export const CodeBlock = ({
+export const Code = ({
 	children,
 	className,
 	raw,
 	noCopy,
 	...props
-}: CodeBlockProps) => {
+}: CodeProps) => {
 	return (
 		<div className="group">
 			<pre
 				className={merge(
-					'not-prose [font-variant-ligatures:none] p-5 rounded-lg overflow-auto focus-ring focus-visible:outline-offset-[-2px]',
+					'not-prose [font-variant-ligatures:none]',
+					'border-none',
+					'p-5 rounded-lg overflow-auto',
+					'focus-ring focus-visible:outline-offset-[-2px]',
 					className
 				)}
 				{...props}
@@ -44,4 +47,4 @@ export const CodeBlock = ({
 	)
 }
 
-export default CodeBlock
+export default Code

--- a/packages/site/src/components/CodeHighlight.tsx
+++ b/packages/site/src/components/CodeHighlight.tsx
@@ -1,0 +1,40 @@
+'use client'
+import type { HTMLAttributes } from 'react'
+import { merge } from '@trikinco/fullstack-components/utils'
+import { Code } from '@/src/components/Code'
+import { useCodeHighlighter } from '@/src/hooks/useCodeHighlighter'
+
+export interface CodeHighlightProps extends HTMLAttributes<HTMLPreElement> {
+	/** raw code contents */
+	raw?: string
+	/** markdown code */
+	code?: string
+	/** whether the copy button should be hidden */
+	noCopy?: boolean
+}
+
+/**
+ * Markdown code block that dynamically highlights code
+ */
+export const CodeHighlight = ({
+	children,
+	className,
+	raw,
+	code,
+	noCopy,
+	...props
+}: CodeHighlightProps) => {
+	const { data } = useCodeHighlighter(code)
+
+	return (
+		<Code
+			className={merge('p-0', className)}
+			raw={raw}
+			noCopy={noCopy}
+			dangerouslySetInnerHTML={{ __html: data }}
+			{...props}
+		/>
+	)
+}
+
+export default CodeHighlight

--- a/packages/site/src/components/Elements/Button.tsx
+++ b/packages/site/src/components/Elements/Button.tsx
@@ -29,7 +29,7 @@ export const Button = <C extends ElementType = typeof defaultElement>({
 			className={merge(
 				'no-underline bg-slate-900 disabled:bg-slate-700 hover:bg-slate-700 focus-ring text-white font-semibold h-12 px-6 rounded-lg w-full flex items-center justify-center sm:w-auto dark:bg-white dark:disabled:bg-white/90 dark:hover:bg-white/90 dark:text-slate-900 dark:highlight-white/20',
 				color === 'secondary' &&
-					'bg-transparent hover:bg-white/20 text-slate-900 dark:bg-slate-900 dark:hover:bg-white/20 dark:text-white',
+					'bg-transparent hover:bg-white/20 text-slate-900 dark:bg-slate-950 dark:hover:bg-white/20 dark:text-white',
 				variant === 'outlined' && 'border-2 border-slate-900 dark:border-white',
 				className
 			)}

--- a/packages/site/src/components/Elements/Input.tsx
+++ b/packages/site/src/components/Elements/Input.tsx
@@ -10,7 +10,10 @@ export function Input({ className, ...rest }: InputProps) {
 	return (
 		<input
 			className={merge(
-				'p-3 rounded-md border text-black bg-white dark:text-white dark:bg-slate-800 border-white/10 w-full focus-ring',
+				'p-3 rounded-md w-full focus-ring',
+				'border border-slate-100 dark:border-white/10',
+				'bg-white dark:bg-slate-800',
+				'text-black dark:text-white',
 				className
 			)}
 			type="text"

--- a/packages/site/src/components/Icons/IconRefresh.tsx
+++ b/packages/site/src/components/Icons/IconRefresh.tsx
@@ -1,6 +1,9 @@
 import type { SVGAttributes } from 'react'
 import { merge } from '@trikinco/fullstack-components/utils'
 
+/**
+ * https://www.svgrepo.com/collection/dazzle-line-icons/
+ */
 export const IconRefresh = ({
 	className,
 	...rest
@@ -14,8 +17,11 @@ export const IconRefresh = ({
 		{...rest}
 	>
 		<path
-			fill="currentColor"
-			d="M13.5 2c-5.621 0-10.211 4.443-10.475 10h-3.025l5 6.625 5-6.625h-2.975c.257-3.351 3.06-6 6.475-6 3.584 0 6.5 2.916 6.5 6.5s-2.916 6.5-6.5 6.5c-1.863 0-3.542-.793-4.728-2.053l-2.427 3.216c1.877 1.754 4.389 2.837 7.155 2.837 5.79 0 10.5-4.71 10.5-10.5s-4.71-10.5-10.5-10.5z"
+			stroke="currentColor"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			strokeWidth="2"
+			d="M3 3v5m0 0h5M3 8l3-2.708A9 9 0 1 1 12 21a9.003 9.003 0 0 1-8.777-7"
 		/>
 	</svg>
 )

--- a/packages/site/src/components/PreviewCode.tsx
+++ b/packages/site/src/components/PreviewCode.tsx
@@ -6,12 +6,15 @@ import {
 } from 'react-error-boundary'
 import { IconEye } from './Icons/IconEye'
 import { IconCode } from './Icons/IconCode'
-import { CodeBlock } from './CodeBlock'
+import { Code } from './Code'
+import { CodeHighlight } from './CodeHighlight'
 
 export interface PreviewCodeProps extends ErrorBoundaryPropsWithFallback {
 	children?: ReactNode
 	/** the code to preview and show */
 	code?: string | null
+	/** language of the code. used for highlighting */
+	lang?: string
 	/** accessible label for the preview iframe */
 	title: string
 }
@@ -19,10 +22,12 @@ export interface PreviewCodeProps extends ErrorBoundaryPropsWithFallback {
 export const PreviewCode = ({
 	title,
 	code,
+	lang = 'html',
 	fallback,
 	children,
 }: PreviewCodeProps) => {
 	const id = useId()
+	const mdCode = code ? '```' + lang + '\n' + code + '\n' + '```' : ''
 
 	return (
 		<div className="relative">
@@ -61,9 +66,7 @@ export const PreviewCode = ({
 						disabled: !code,
 						children: (
 							<div className="aspect-square md:aspect-video rounded-lg shadow-lg overflow-auto bg-[--shiki-color-background] border border-slate-300 dark:border-white/20">
-								<CodeBlock noCopy raw={code || ''}>
-									{code}
-								</CodeBlock>
+								<CodeHighlight noCopy raw={code || ''} code={mdCode} />
 							</div>
 						),
 					},

--- a/packages/site/src/hooks/useCodeHighlighter.ts
+++ b/packages/site/src/hooks/useCodeHighlighter.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkRehype from 'remark-rehype'
+import rehypeStringify from 'rehype-stringify'
+import rehypePrettyCode, { Theme, Options } from 'rehype-pretty-code'
+import theme from '@/src/assets/themes/css-variables.json' assert { type: 'json' }
+
+export async function highlightCode(code: string, options?: Options) {
+	const file = await unified()
+		.use(remarkParse)
+		.use(remarkRehype)
+		.use(
+			rehypePrettyCode,
+			/**
+			 * Use the 'css-variables' theme to enable easy custom styling for light and dark mode
+			 * @note styles are defined in `src/styles/globals.css`
+			 * @see {@link https://github.com/shikijs/shiki/blob/main/docs/themes.md#theming-with-css-variables theming with CSS variables}
+			 */
+			{
+				theme: theme as unknown as Theme,
+				keepBackground: false,
+				...options,
+			}
+		)
+		.use(rehypeStringify)
+		.process(code)
+
+	return file.toString()
+}
+
+export function useCodeHighlighter(code?: string, options?: Options) {
+	const [isLoading, setIsLoading] = useState(false)
+	const [highlightedCode, setHighlightedCode] = useState('')
+
+	useEffect(() => {
+		if (!code || isLoading) return
+
+		async function handleCode(code: string) {
+			try {
+				setIsLoading(true)
+				const result = await highlightCode(code, options)
+				setHighlightedCode(result)
+			} catch (error) {
+				console.error('Error while highlighting code: ', error)
+			} finally {
+				setIsLoading(false)
+			}
+		}
+
+		handleCode(code)
+	}, [code, options, isLoading])
+
+	return {
+		isLoading,
+		data: highlightedCode,
+	}
+}

--- a/packages/site/src/modules/HTMLPage.tsx
+++ b/packages/site/src/modules/HTMLPage.tsx
@@ -1,7 +1,7 @@
 import { Chip } from '@/src/components/Chip'
 import { IconRefresh } from '@/src/components/Icons/IconRefresh'
 import { Spinner } from '@/src/components/Spinner'
-import { PreviewCode } from '../components/PreviewCode'
+import { PreviewCode } from '@/src/components/PreviewCode'
 
 export interface HTMLPageProps {
 	/** Refetch with current form values */
@@ -63,7 +63,7 @@ export function HTMLPage({
 				)}
 			</PreviewCode>
 
-			<div className="flex gap-3">
+			<div className="relative flex gap-3 z-10">
 				{(!!state || isError) && (
 					<button
 						disabled={isLoading}

--- a/packages/site/src/modules/Search/Search.tsx
+++ b/packages/site/src/modules/Search/Search.tsx
@@ -46,7 +46,7 @@ export function Search({
 			{/* Search backdrop */}
 			{shouldShowList && (
 				<div
-					className="fixed m-0 w-full h-screen top-0 left-0 z-10 bg-white/30 dark:bg-slate-950/30"
+					className="fixed m-0 w-full h-screen top-0 left-0 z-10 bg-black/10"
 					onClick={() => setIsShown(false)}
 				/>
 			)}

--- a/packages/site/src/modules/Search/SearchInput.tsx
+++ b/packages/site/src/modules/Search/SearchInput.tsx
@@ -72,7 +72,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 					ref={ref}
 					spellCheck={false}
 					className={merge(
-						'block w-full appearance-none rounded-lg pl-3 pr-3 md:pr-12 py-2 transition-colors',
+						'block w-full appearance-none rounded-md pl-3 pr-3 md:pr-12 py-2 transition-colors',
 						'text-base md:text-sm',
 						'bg-black/[.05] dark:bg-slate-50/10',
 						'focus:bg-white dark:focus:bg-slate-900',
@@ -96,6 +96,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 					type="search"
 					placeholder="Search documentation..."
 					role="combobox"
+					maxLength={100}
 					aria-controls={id}
 					aria-expanded={isFocused}
 					aria-activedescendant={`${id}-option-${activeResult}`}

--- a/packages/site/src/modules/Search/useFlexSearch.tsx
+++ b/packages/site/src/modules/Search/useFlexSearch.tsx
@@ -324,7 +324,6 @@ export function useFlexSearch({
 		results,
 		search,
 		preload,
-		doSearch,
 		handleChange,
 	}
 }

--- a/packages/site/src/styles/globals.css
+++ b/packages/site/src/styles/globals.css
@@ -37,23 +37,32 @@ body {
 }
 
 /* outer code blocks */
-[data-rehype-pretty-code-fragment] {
+[data-rehype-pretty-code-figure] {
 	font-variant-ligatures: none;
 	background-color: var(--shiki-color-background);
 	@apply relative overflow-hidden my-10 font-mono rounded-lg border border-slate-300 dark:border-white/20;
 }
 
-.typeinfo [data-rehype-pretty-code-fragment] {
+.typeinfo [data-rehype-pretty-code-figure] {
 	@apply my-3;
 }
 
-[data-rehype-pretty-code-fragment] code {
+[data-rehype-pretty-code-figure] code {
 	@apply text-sm leading-6;
 }
 
+[data-rehype-pretty-code-figure] [data-line] {
+	@apply pr-5;
+}
+
 /* hide copy button for code blocks with a `title` including `:nocopy` */
-[data-rehype-pretty-code-fragment]:has([data-copy='false']) [data-copy] {
+[data-rehype-pretty-code-figure]:has([data-copy='false']) [data-copy] {
 	@apply hidden;
+}
+
+/* Styles nested code blocks or code blocks inside PreviewCode */
+pre [data-rehype-pretty-code-figure] {
+	@apply my-0 p-5 border-none overflow-auto;
 }
 
 /* code block `title` (usually the file name) */

--- a/packages/site/src/utils/markdown.ts
+++ b/packages/site/src/utils/markdown.ts
@@ -1,4 +1,4 @@
-import { CodeBlock } from '../components/CodeBlock'
+import { Code } from '../components/Code'
 import { Example } from '../components/Example'
 import { TypeInfoToText } from '../components/TypeInfo/TypeInfoToText'
 
@@ -7,7 +7,7 @@ import { TypeInfoToText } from '../components/TypeInfo/TypeInfoToText'
  * Remote and local mdx
  */
 export const defaultComponents = {
-	pre: CodeBlock,
+	pre: Code,
 	Example,
 	TypeInfoToText,
 }

--- a/packages/site/tailwind.config.ts
+++ b/packages/site/tailwind.config.ts
@@ -10,7 +10,7 @@ const config: Config = {
 			mono: ['var(--font-mono)', ...defaultTheme.fontFamily.mono],
 		},
 	},
-	plugins: [require('@tailwindcss/typography')],
+	plugins: [require('@tailwindcss/typography'), require('autoprefixer')],
 	safelist: [
 		{
 			/**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,8 +193,8 @@ importers:
         specifier: 7.0.0
         version: 7.0.0
       rehype-pretty-code:
-        specifier: 0.11.0
-        version: 0.11.0(shiki@0.14.5)
+        specifier: 0.12.3
+        version: 0.12.3(shikiji@0.9.17)
       rehype-slug:
         specifier: 6.0.0
         version: 6.0.0
@@ -216,9 +216,9 @@ importers:
       remark-rehype:
         specifier: 11.0.0
         version: 11.0.0
-      shiki:
-        specifier: 0.14.5
-        version: 0.14.5
+      shikiji:
+        specifier: 0.9.17
+        version: 0.9.17
       unified:
         specifier: 11.0.4
         version: 11.0.4
@@ -6408,10 +6408,6 @@ packages:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
 
-  /ansi-sequence-parser@1.1.1:
-    resolution: {integrity: sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==}
-    dev: false
-
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
@@ -9942,15 +9938,6 @@ packages:
       safe-buffer: 5.2.1
     dev: true
 
-  /hash-obj@4.0.0:
-    resolution: {integrity: sha512-FwO1BUVWkyHasWDW4S8o0ssQXjvyghLV2rfVhnN36b2bbcj45eGiuzdn9XOvOpjV3TKQD7Gm2BWNXdE9V4KKYg==}
-    engines: {node: '>=12'}
-    dependencies:
-      is-obj: 3.0.0
-      sort-keys: 5.0.0
-      type-fest: 1.4.0
-    dev: false
-
   /hash.js@1.1.7:
     resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
     dependencies:
@@ -10650,11 +10637,6 @@ packages:
   /is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
-    dev: false
-
-  /is-obj@3.0.0:
-    resolution: {integrity: sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==}
-    engines: {node: '>=12'}
     dev: false
 
   /is-path-cwd@2.2.0:
@@ -11477,10 +11459,6 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
-
-  /jsonc-parser@3.2.0:
-    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
-    dev: false
 
   /jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
@@ -14436,18 +14414,17 @@ packages:
       unified: 11.0.4
     dev: false
 
-  /rehype-pretty-code@0.11.0(shiki@0.14.5):
-    resolution: {integrity: sha512-VCyDXrVio14Ipt+A5rTw3My17yjNOen12HqYuYaMIOj6m+WuqpAeYdTIlqIab+2PkWuTgzA2XCZgAHMHjUS4IQ==}
-    engines: {node: '>=16'}
+  /rehype-pretty-code@0.12.3(shikiji@0.9.17):
+    resolution: {integrity: sha512-6NbIit8A3hLrkKBEbNs862jVnTLeIOM2AmM0VZ/MtyHb+OuNMeCa6UZSx6UG4zrobm5tY9efTwhih1exsGYsiw==}
+    engines: {node: '>=18'}
     peerDependencies:
-      shiki: 0.x
+      shikiji: ^0.7.0 || ^0.8.0 || ^0.9.0
     dependencies:
       '@types/hast': 3.0.3
-      hash-obj: 4.0.0
       hast-util-to-string: 3.0.0
       parse-numeric-range: 1.3.0
       rehype-parse: 9.0.0
-      shiki: 0.14.5
+      shikiji: 0.9.17
       unified: 11.0.4
       unist-util-visit: 5.0.0
     dev: false
@@ -14958,13 +14935,14 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  /shiki@0.14.5:
-    resolution: {integrity: sha512-1gCAYOcmCFONmErGTrS1fjzJLA7MGZmKzrBNX7apqSwhyITJg2O102uFzXUeBxNnEkDA9vHIKLyeKq0V083vIw==}
+  /shikiji-core@0.9.17:
+    resolution: {integrity: sha512-r1FWTXk6SO2aYqfWgcsJ11MuVQ1ymPSdXzJjK7q8EXuyqu8yc2N5qrQy5+BL6gTVOaF4yLjbxFjF+KTRM1Sp8Q==}
+    dev: false
+
+  /shikiji@0.9.17:
+    resolution: {integrity: sha512-0z/1NfkhBkm3ijrfFeHg3G9yDNuHhXdAGbQm7tRxj4WQ5z2y0XDbnagFyKyuV2ebCTS1Mwy1I3n0Fzcc/4xdmw==}
     dependencies:
-      ansi-sequence-parser: 1.1.1
-      jsonc-parser: 3.2.0
-      vscode-oniguruma: 1.7.0
-      vscode-textmate: 8.0.0
+      shikiji-core: 0.9.17
     dev: false
 
   /side-channel@1.0.4:
@@ -15053,13 +15031,6 @@ packages:
     dependencies:
       solid-js: 1.8.7
       swr-store: 0.10.6
-    dev: false
-
-  /sort-keys@5.0.0:
-    resolution: {integrity: sha512-Pdz01AvCAottHTPQGzndktFNdbRA75BgOfeT1hH+AMnJFv8lynkPi42rfeEhpx1saTEI3YNMWxfqu0sFD1G8pw==}
-    engines: {node: '>=12'}
-    dependencies:
-      is-plain-obj: 4.1.0
     dev: false
 
   /source-map-js@1.0.2:
@@ -16334,14 +16305,6 @@ packages:
   /vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
     dev: true
-
-  /vscode-oniguruma@1.7.0:
-    resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
-    dev: false
-
-  /vscode-textmate@8.0.0:
-    resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
-    dev: false
 
   /vue@3.3.13(typescript@5.2.2):
     resolution: {integrity: sha512-LDnUpQvDgsfc0u/YgtAgTMXJlJQqjkxW1PVcOnJA5cshPleULDjHi7U45pl2VJYazSSvLH8UKcid/kzH8I0a0Q==}


### PR DESCRIPTION
<img width="1582" alt="Screenshot 2024-01-08 at 16 16 51" src="https://github.com/trikinco/fullstack-components/assets/7847281/dfb3b498-d5cf-47a1-9537-5c5df6457649">

- upgrades rehype-pretty-code and replaces shiki with shikiji (ESM port of shiki)
- allow for client-side syntax highlighting
- adds css-variables shiki theme to json file due to updated deps not packaging the theme anymore
- slight tweaks to styling of code to account for new names, nested code blocks and consistency
- adds autoprefixer to tailwind config
- prevent the highlighter lib from loading more langs than needed: use tsx
- avoid form submissions from copying code
- consistent input borders, rounding
- use dazzle line icons for refresh
- adds maxLength to search
