### PR TITLE
docs(site): Clearer demos, consistent sections for custom server components, and always visible breadcrumbs

### DIFF
--- a/packages/site/src/app/docs/audio/GetAudio.tsx
+++ b/packages/site/src/app/docs/audio/GetAudio.tsx
@@ -7,9 +7,9 @@ export default async function Page() {
 		voice: 'onyx',
 	})
 
-	const base64String = Buffer.from(responseFile).toString('base64')
+	if (!responseFile) return 'No reminders.'
 
-	if (!base64String) return 'No reminders.'
+	const base64String = Buffer.from(responseFile).toString('base64')
 
 	return (
 		<a href={`data:${contentType};base64,${base64String}`} download>

--- a/packages/site/src/app/docs/audio/GetAudio.tsx
+++ b/packages/site/src/app/docs/audio/GetAudio.tsx
@@ -1,0 +1,19 @@
+import { getAudio } from '@trikinco/fullstack-components'
+
+export default async function Page() {
+	const { responseFile, contentType } = await getAudio({
+		mode: 'speech',
+		content: 'It is Wednesday my dudes',
+		voice: 'onyx',
+	})
+
+	const base64String = Buffer.from(responseFile).toString('base64')
+
+	if (!base64String) return 'No reminders.'
+
+	return (
+		<a href={`data:${contentType};base64,${base64String}`} download>
+			Download reminder
+		</a>
+	)
+}

--- a/packages/site/src/app/docs/audio/page.mdx
+++ b/packages/site/src/app/docs/audio/page.mdx
@@ -2,6 +2,7 @@ import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
 import { Audio, Transcript } from '@trikinco/fullstack-components'
 import CenteredTrackCues from './CenteredTrackCues'
+import GetAudio from './GetAudio'
 
 export const metadata = {
   title:
@@ -15,13 +16,15 @@ export const metadata = {
 
 # Audio
 
-Generate speech from text or transcribe audio to text. Includes multiple Server Components, custom hooks and more.
+Generate speech from text, and transcribe audio into text or create accessible [WebVTT](https://www.w3.org/TR/webvtt1/) captions.
 
 ## Server Components
 
-### `Audio` component
+### `<Audio>` Server Component
 
-Creates an audio file from text `content` or a React tree. Also generates VTT captions for the audio file for accessibility.
+Creates an audio file from text `content` or a React tree. The component also generates WebVTT captions for the audio file to improve accessibility.
+
+Consumes `<Track>` for generating the captions, unless the `noCaption` prop is `true`.
 
 <Example>
   <Audio
@@ -64,13 +67,13 @@ Creates an audio file from text `content` or a React tree. Also generates VTT ca
 </Audio>
 ```
 
-**Note, file size constraints**: the `Audio` and `Track` Server Components currently transform the response body to base64 data URLs.
-This affects the maximum file size that can be generated.
+**Note on file size constraints**: the `<Audio>` and `<Track>` Server Components currently transform the response body to base64 data URLs and this affects the maximum file size that can be generated.
+
 Data URLs are used to inline the data instead of storing the audio and caption files on the server. This may change in the future.
 
 If you want to store the files yourself, you can build your own Server Components using the `getAudio` utility function.
 
-### `Track` component
+### `<Track>` Server Component
 
 Creates VTT captions from an audio file.
 
@@ -79,9 +82,9 @@ Creates VTT captions from an audio file.
 </Example>
 
 ```tsx {12}
-// Using a video element here
+// Using a video element for this demo
 // to visibly show the captions.
-// `Audio` Server Component already uses `Track`.
+// The `<Audio>` Server Component already uses `<Track>`.
 <video
   controls
   className="aspect-video w-full [&::cue]:text-base"
@@ -94,7 +97,7 @@ Creates VTT captions from an audio file.
 </video>
 ```
 
-### `Transcript` component
+### `<Transcript>` Server Component
 
 Transcribes an audio file to text.
 
@@ -118,7 +121,7 @@ Transcribes an audio file to text.
 
 `useAudio` is a utility hook that allows for full access to the same features as `getAudio`, in addition to the ability to control the audio file playback.
 
-```tsx
+```tsx {5-15}
 'use client'
 import { useAudio } from '@trikinco/fullstack-components/client'
 
@@ -151,6 +154,38 @@ export default function Page() {
         <button onClick={() => setPlayBackRate(2)}>2.0x</button>
       </div>
     </div>
+  )
+}
+```
+
+## Custom Server Component with `getAudio`
+
+<Example>
+  <GetAudio />
+</Example>
+
+```tsx {4-8} title="Server Component"
+import { getAudio } from '@trikinco/fullstack-components'
+
+export default async function Page() {
+  const { responseFile, contentType } = await getAudio({
+    mode: 'speech',
+    content: 'It is Wednesday my dudes',
+    voice: 'onyx',
+  })
+
+  const base64String =
+    Buffer.from(responseFile).toString('base64')
+
+  if (!base64String) return 'No reminders.'
+
+  return (
+    <a
+      href={`data:${contentType};base64,${base64String}`}
+      download
+    >
+      Download reminder
+    </a>
   )
 }
 ```

--- a/packages/site/src/app/docs/audio/page.mdx
+++ b/packages/site/src/app/docs/audio/page.mdx
@@ -174,10 +174,10 @@ export default async function Page() {
     voice: 'onyx',
   })
 
+  if (!responseFile) return 'No reminders.'
+
   const base64String =
     Buffer.from(responseFile).toString('base64')
-
-  if (!base64String) return 'No reminders.'
 
   return (
     <a

--- a/packages/site/src/app/docs/block/page.mdx
+++ b/packages/site/src/app/docs/block/page.mdx
@@ -13,9 +13,9 @@ export const metadata = {
 
 # Block
 
-Blocks are individual React components that are generated and mounted on the fly, and all you need is a `prompt`.
+Block generates and mounts a React component at runtime based on a `prompt` text description.
 
-## `Block` Client Component
+## `<Block>` Client Component
 
 <Example className="w-full xl:w-auto xl:-mx-10 2xl:-mx-28">
   <Blocks />

--- a/packages/site/src/app/docs/error-enhancer/ErrorEnhancementFallbackDemo.tsx
+++ b/packages/site/src/app/docs/error-enhancer/ErrorEnhancementFallbackDemo.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { ErrorEnhancementFallback } from '@trikinco/fullstack-components/client'
+
+export default function Page() {
+	return (
+		<ErrorEnhancementFallback
+			error={new Error('Failed to get more cowbell')}
+			resetErrorBoundary={() => null}
+		/>
+	)
+}

--- a/packages/site/src/app/docs/error-enhancer/page.mdx
+++ b/packages/site/src/app/docs/error-enhancer/page.mdx
@@ -15,7 +15,7 @@ export const metadata = {
 
 # Error Enhancer
 
-These error enhancement tools can be used to show users helpful information parsed from an `Error` object, or in-depth debugging help for developers.
+These error enhancement tools analyze information from an `Error` object, providing users with helpful insights and offering developers in-depth debugging assistance.
 
 ## `<ErrorEnhancementBoundary>` Client Component
 

--- a/packages/site/src/app/docs/error-enhancer/page.mdx
+++ b/packages/site/src/app/docs/error-enhancer/page.mdx
@@ -2,6 +2,7 @@ import { ErrorHTTPPreview } from './ErrorHTTPPreview'
 import { ClientErrors } from './ClientErrors'
 import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
+import ErrorEnhancementFallbackDemo from './ErrorEnhancementFallbackDemo'
 
 export const metadata = {
   title: 'Error Enhancer - AI-Powered Smart Error Boundary',
@@ -14,13 +15,101 @@ export const metadata = {
 
 # Error Enhancer
 
-These error enhancement tools can be used to show users a user-friendly message parsed from an `Error` object, or an in-dept debugging message for developers.
+These error enhancement tools can be used to show users helpful information parsed from an `Error` object, or in-depth debugging help for developers.
+
+## `<ErrorEnhancementBoundary>` Client Component
+
+A smart [error boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) Client Component that parses an `Error` object and stack trace, then generates and displays messages aimed to help users and developers.
+
+- In **development** the component shows in-depth debugging help for developers.
+- In **production** the component shows user-friendly messages.
+
+Consumes [`react-error-boundary`](https://www.npmjs.com/package/react-error-boundary), `useErrorEnhancement` and `<ErrorEnhancementFallback>` under the hood to generate and display the enhanced error messages.
+
+### Handling client errors with `<ErrorEnhancementBoundary>`
+
+<ClientErrors />
+
+```tsx title="Client Component"
+'use client'
+
+import { ErrorEnhancementBoundary } from '@trikinco/fullstack-components/client'
+
+export default function ComponentThatMayThrow() {
+  return (
+    <ErrorEnhancementBoundary
+      fallback={
+        <p>Generating a user-friendly error message...</p>
+      }
+    >
+      <Button
+        onClick={() => {
+          throwsCowbellOrError()
+        }}
+      >
+        Howdy 🤠
+      </Button>
+    </ErrorEnhancementBoundary>
+  )
+}
+```
+
+## `<ErrorEnhancementFallback>` Client Component
+
+A Client Component to render inside your own [error boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) or a [`react-error-boundary`](https://www.npmjs.com/package/react-error-boundary). `<ErrorEnhancementFallback>` handles enhancing error messages and rendering the information.
+
+Consumes `useErrorEnhancement` under the hood to generate and display the enhanced error messages.
+
+<Example lazy>
+  <ErrorEnhancementFallbackDemo />
+</Example>
+
+```tsx
+'use client'
+import { ErrorEnhancementFallback } from '@trikinco/fullstack-components/client'
+
+export default function Page() {
+  return (
+    <ErrorEnhancementFallback
+      error={new Error('Failed to get more cowbell')}
+      resetErrorBoundary={() => null}
+    />
+  )
+}
+```
+
+### Usage with `react-error-boundary`
+
+The most common use for `<ErrorEnhancementFallback>` is inside an error boundary, where the error to parse must be passed down for it to generate messages.
+
+```tsx {9-13}
+'use client'
+import { ErrorBoundary } from 'react-error-boundary'
+
+export default function SmartBoundary(props) {
+  const { children, ...rest } = props || {}
+  return (
+    <ErrorBoundary
+      fallbackRender={({ error, resetErrorBoundary }) => (
+        // Handles enhancing errors and rendering UI
+        <ErrorEnhancementFallback
+          error={error}
+          resetErrorBoundary={resetErrorBoundary}
+          {...rest}
+        />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  )
+}
+```
 
 ## `useErrorEnhancement` hook
 
-```tsx
-import { useErrorEnhancement } from '@trikinco/fullstack-components/client'
-```
+A client-side hook for parsing information from an `Error` object or other source and creating helpful messages for users and developers.
+
+See [ErrorEnhancementRequestBody](#errorenhancementrequestbody) for available parameters.
 
 ### Handling network errors with the `useErrorEnhancement` hook
 
@@ -63,6 +152,10 @@ export default function Page({ error }) {
   const { isLoading, data } = useErrorEnhancement({
     errorMessage: error?.message,
     stackTrace: error?.stack,
+    // Optional
+    // Contextual info which may help with debugging.
+    errorContext:
+      'The endpoint handling /users is down for maintenance',
   })
 
   if (isLoading) {
@@ -77,40 +170,6 @@ export default function Page({ error }) {
       <p>{data?.message}</p>
       <p>{data?.developmentModeContext}</p>
     </div>
-  )
-}
-```
-
-## `ErrorEnhancementBoundary` Client Component
-
-```tsx
-import { ErrorEnhancementBoundary } from '@trikinco/fullstack-components/client'
-```
-
-### Handling client errors with `ErrorEnhancementBoundary`
-
-<ClientErrors />
-
-```tsx title="Client Component"
-'use client'
-
-import { ErrorEnhancementBoundary } from '@trikinco/fullstack-components/client'
-
-export default function ComponentThatMayThrow() {
-  return (
-    <ErrorEnhancementBoundary
-      fallback={
-        <p>Generating a user-friendly error message...</p>
-      }
-    >
-      <Button
-        onClick={() => {
-          throwsCowbellOrError()
-        }}
-      >
-        Howdy 🤠
-      </Button>
-    </ErrorEnhancementBoundary>
   )
 }
 ```
@@ -131,9 +190,10 @@ const fscOptions: FSCOptions = {
     openAiApiKey: process.env.OPENAI_API_KEY || '',
     appContext: 'http web app',
     /**
-     * `isProd` overrides the output of `developmentModeContext`
-     * messages that are typically only shown when
-     * `process.env.NODE_ENV === 'development'`
+     * Overrides the output of `developmentModeContext` messages are
+     * shown when `process.env.NODE_ENV === 'development'`.
+     *
+     * See below for more info.
      */
     isProd: true,
   }),
@@ -144,6 +204,11 @@ const fscHandler = handleFSComponents(fscOptions)
 
 export { fscHandler as GET, fscHandler as POST }
 ```
+
+### `isProd`
+
+- Omitting `isProd`, `isProd: undefined` or `isProd: false` shows developer debugging messages if `process.env.NODE_ENV === 'development'`
+- `isProd: true` shows user-friendly messages regardless of `process.env.NODE_ENV`
 
 ## API Reference
 

--- a/packages/site/src/app/docs/html-page-generator/page.mdx
+++ b/packages/site/src/app/docs/html-page-generator/page.mdx
@@ -13,12 +13,12 @@ export const metadata = {
 
 # HTML Page Generator
 
-AI-Powered HTML page generator utilities that designs and codes user interfaces.
-
-The below HTML page generator and preview is an example of the kinds of interfaces and interactions you can build with `useHtmlPage`.
+AI-Powered HTML page generator utilities to help you create your own generative UI experiences.
 
 <p className="ml-3 mb-3 mt-6 text-sm font-bold font-mono">{`Live Example`}</p>
 <Form className="mt-8 pt-8 border-t border-black/20 dark:border-white/20" />
+
+This HTML page generator and preview is just a basic example of the kinds of interfaces and interactions you can build with `useHtmlPage`.
 
 ## `useHtmlPage` hook
 
@@ -77,7 +77,7 @@ export default async function Page() {
     src: 'https://speed-boat-designs.dev/inspiration.png',
     colors: 'blue-400,teal-200',
     theme: 'light',
-    // `html` is only needed if iterating on an existing / previously generated page
+    // `html` is only used if iterating on a previously generated page
     html: '<!DOCTYPE html><html>...</html>',
   })
 

--- a/packages/site/src/app/docs/image/page.mdx
+++ b/packages/site/src/app/docs/image/page.mdx
@@ -13,9 +13,9 @@ export const metadata = {
 
 # Image
 
-A smart image component that either describes a known image, generates an image based on a prompt, or behaves just like a regular `next/image`.
+A smart image component that either outputs text descriptions of an image, generates an image based on a prompt, or behaves just like a regular `next/image`.
 
-## `Image` Server Component
+## `<Image>` Server Component
 
 ### Describing an image
 
@@ -28,7 +28,7 @@ A smart image component that either describes a known image, generates an image 
   />
 </Example>
 
-```tsx
+```tsx title="Generating alt text from an image"
 <Image
   src="https://absolute-cat-url/tabbycat.jpg"
   showResult // Optional - to render the alt-text visually
@@ -47,8 +47,9 @@ A smart image component that either describes a known image, generates an image 
   />
 </Example>
 
-```tsx
+```tsx title="Creating an image from a prompt"
 <Image
+  // The prompt is also used for the `alt` unless specified
   prompt="A photograph of a cat wearing a cowboy hat"
   model="dall-e-3"
   size="1024x1024"
@@ -56,6 +57,12 @@ A smart image component that either describes a known image, generates an image 
 ```
 
 ### Fallback To Standard `next/image`
+
+`<Image>` also works great even if you specify `src`, `alt` and no `prompt`.
+
+This is useful for cases where you might be dynamically setting props, and want to ensure that you'll always be able to fall back and display your images as expected.
+
+See the [Next.js `<Image>` documentation](https://nextjs.org/docs/pages/api-reference/components/image) for more information.
 
 <Example>
   <Image
@@ -66,7 +73,7 @@ A smart image component that either describes a known image, generates an image 
   />
 </Example>
 
-```tsx
+```tsx title="Usage as a regular image"
 <Image
   src="/images/MobiusStrip.png"
   alt="A white coiling mobius strip"
@@ -77,15 +84,11 @@ A smart image component that either describes a known image, generates an image 
 
 ## `useImage` hook
 
-`useImage` is a utility hook that allows for full access to the same features as `Image`, in addition to being able to generate multiple images.
-
-```tsx
-import { useImage } from '@trikinco/fullstack-components/client'
-```
+A utility hook that allows for full access to the same features as `Image`, in addition to being able to generate multiple images.
 
 ### `useImage` image description with `src`
 
-```tsx
+```tsx {6-8}
 'use client'
 
 import { useImage } from '@trikinco/fullstack-components/client'
@@ -103,17 +106,13 @@ export default function Page() {
     return 'Could not describe image'
   }
 
-  return (
-    <div className="rounded-md overflow-hidden p-6 bg-sky-200 text-sky-800 text-xl">
-      {data}
-    </div>
-  )
+  return <span>{data}</span>
 }
 ```
 
 ### `useImage` image generation of multiple images with `prompt` and `n`
 
-```tsx
+```tsx {6-9}
 'use client'
 
 import { useImage } from '@trikinco/fullstack-components/client'
@@ -144,13 +143,18 @@ export default function Page() {
 }
 ```
 
-```tsx title="Server Component"
+## Custom Server Component with `getImage`
+
+```tsx {4-10} title="Server Component"
 import { getImage } from '@trikinco/fullstack-components'
 
 export default async function Page() {
   const { responseText } = await getImage({
-    prompt:
-      'An ethereal landscape in a far away fantasy land, natural light, golden hour',
+    prompt: `
+    An ethereal landscape in a far away fantasy land, 
+    natural light, 
+    golden hour
+    `,
   })
 
   return (

--- a/packages/site/src/app/docs/layout.tsx
+++ b/packages/site/src/app/docs/layout.tsx
@@ -15,22 +15,22 @@ export default async function Layout({ children }: { children: ReactNode }) {
 
 	return (
 		<>
-			<Breadcrumbs className="px-6 py-3 " />
 			<Main
 				as="div"
 				id="content"
 				className="items-start lg:justify-center lg:mx-auto lg:max-w-screen-2xl lg:grid lg:grid-rows-none lg:grid-cols-12"
 			>
-				<DocsNav className="hidden lg:sticky lg:top-32 lg:left-0 lg:flex w-full max-w-prose mx-auto lg:mx-0 lg:col-start-1 lg:col-end-3" />
+				<DocsNav className="row-start-1 row-end-3 hidden lg:sticky lg:top-32 lg:left-0 lg:flex w-full max-w-prose mx-auto lg:mx-0 lg:col-start-1 lg:col-end-3" />
+				<Breadcrumbs className="row-start-1 py-3 md:py-0 lg:mb-2 w-full max-w-prose mx-auto col-span-full md:col-start-3 md:col-end-11" />
 				<Prose
 					as="main"
 					id={ID_MAIN}
-					className="col-span-full md:col-start-3 md:col-end-11"
+					className="row-start-2 col-span-full md:col-start-3 md:col-end-11"
 				>
 					{children}
 				</Prose>
 				<DocsToc
-					className="hidden lg:sticky lg:top-32 lg:right-0 lg:flex w-full max-w-prose mx-auto lg:mx-0 lg:col-start-11 lg:col-span-2"
+					className="row-start-1 row-end-3 hidden lg:sticky lg:top-32 lg:right-0 lg:flex w-full max-w-prose mx-auto lg:mx-0 lg:col-start-11 lg:col-span-2"
 					tocMarkupByRoutes={tocMarkupByRoutes}
 				/>
 				<DocsFooter className="w-full lg:w-auto col-span-full md:col-start-3 md:col-end-11" />

--- a/packages/site/src/app/docs/not-found-enhancer/page.mdx
+++ b/packages/site/src/app/docs/not-found-enhancer/page.mdx
@@ -82,6 +82,7 @@ import {
 const fscOptions: FSCOptions = {
   notFoundEnhancer: handleNotFoundEnhancement({
     openAiApiKey: process.env.OPENAI_API_KEY || '',
+    // Required
     siteUrl: process.env.NEXT_PUBLIC_HOST || '',
   }),
   // Additional options and handlers...
@@ -92,7 +93,10 @@ const fscHandler = handleFSComponents(fscOptions)
 export { fscHandler as GET, fscHandler as POST }
 ```
 
-**Not Found Enhancer requires configuration of the API handler and a sitemap available at `/sitemap.xml`.**
+**Not Found Enhancer requires:**
+
+- Configuration of the API handler route with your `siteUrl`
+- A sitemap available at `/sitemap.xml`
 
 ## API Reference
 

--- a/packages/site/src/app/docs/prompt/UsePrompt.tsx
+++ b/packages/site/src/app/docs/prompt/UsePrompt.tsx
@@ -5,12 +5,11 @@ import { usePrompt } from '@trikinco/fullstack-components/client'
 export default function Page() {
 	const { isLoading, data } = usePrompt({
 		prompt: 'What is the longest river in the world?',
-		format: 'JSON',
 	})
 
 	if (isLoading) {
 		return 'Loading...'
 	}
 
-	return <div className="max-w-prose">{JSON.stringify(data)}</div>
+	return <p>{data}</p>
 }

--- a/packages/site/src/app/docs/prompt/UsePromptJSON.tsx
+++ b/packages/site/src/app/docs/prompt/UsePromptJSON.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { usePrompt } from '@trikinco/fullstack-components/client'
+
+export default function Page() {
+	// Optional, type variable to infer the right type for `data`
+	const { isLoading, data } = usePrompt<{ rivers: string[] }>({
+		// Required, JSON mode
+		format: 'JSON',
+		prompt: `
+    What are the 5 longest rivers in the world?
+    Return JSON in the format: {"rivers": string[]} 
+    `, // 👆 Specifying the schema in the prompt is required
+		// You can play around with the wording
+	})
+
+	if (isLoading) {
+		return 'Loading...'
+	}
+
+	return <ol>{data?.rivers.map((river) => <li key={river}>{river}</li>)}</ol>
+}

--- a/packages/site/src/app/docs/prompt/page.mdx
+++ b/packages/site/src/app/docs/prompt/page.mdx
@@ -1,5 +1,6 @@
 import { Prompt } from '@trikinco/fullstack-components'
 import UsePrompt from './UsePrompt'
+import UsePromptJSON from './UsePromptJSON'
 import { URL_HOST } from '@/src/utils/constants'
 import { routes } from '@/src/utils/routes'
 
@@ -14,10 +15,10 @@ export const metadata = {
 
 # Prompt
 
-The `Prompt` component and its counterparts `usePrompt` and `getPrompt` are the most basic building blocks for AI-powered components.
-They accept a text `prompt` and arrays of `messages` and return the data as-is.
+The `<Prompt>` Server Component and its counterparts `usePrompt` and `getPrompt` are the most basic building blocks for AI-powered components.
+They accept a text `prompt` or arrays of `messages` and return the response as-is.
 
-## `Prompt` Server Component
+## `<Prompt>` Server Component
 
 ### Passing a single `prompt`
 
@@ -88,7 +89,7 @@ In addition, this allows you to pass in any of the standard HTML attributes as e
 
 `usePrompt` is a utility hook that allows for full access to the same features as `Prompt`, in addition to the ability to enable JSON mode with the `format` option.
 
-<Example>
+<Example lazy>
   <UsePrompt />
 </Example>
 
@@ -98,9 +99,6 @@ import { usePrompt } from '@trikinco/fullstack-components/client'
 
 export default function Page() {
   const { isLoading, data } = usePrompt({
-    // Enable JSON mode
-    format: 'JSON',
-    // Prompt. You can also define the desired response JSON schema here.
     prompt: 'What is the longest river in the world?',
   })
 
@@ -108,11 +106,48 @@ export default function Page() {
     return 'Loading...'
   }
 
-  return <div className="max-w-prose">{JSON.stringify(data)}</div>
+  return <p>{data}</p>
 }
 ```
 
-```tsx title="Server Component"
+### `usePrompt` in JSON mode with a strict schema
+
+<Example isProse lazy>
+  <UsePromptJSON />
+</Example>
+
+```tsx {8,11} title="Specifying a JSON schema"
+'use client'
+import { usePrompt } from '@trikinco/fullstack-components/client'
+
+export default function Page() {
+  // Optional, type variable to infer the return type for `data`
+  const { isLoading, data } = usePrompt<{ rivers: string[] }>({
+    // Required, JSON mode
+    format: 'JSON',
+    prompt: `
+    What are the 5 longest rivers in the world?
+    Return JSON: {"rivers": string[]}
+    `,
+    // 👆 Specifying the schema in the prompt is required.
+    // You can play around with the wording.
+  })
+
+  if (isLoading) {
+    return 'Loading...'
+  }
+
+  return (
+    <ol>
+      {data?.rivers.map((river) => <li key={river}>{river}</li>)}
+    </ol>
+  )
+}
+```
+
+## Custom Server Component with `getPrompt`
+
+```tsx {4-6} title="Server Component"
 import { getPrompt } from '@trikinco/fullstack-components'
 
 export default async function Page() {
@@ -120,7 +155,7 @@ export default async function Page() {
     prompt: 'Tell me about TailwindCSS',
   })
 
-  return <div>{responseText}</div>
+  return <p>{responseText}</p>
 }
 ```
 

--- a/packages/site/src/app/docs/select/page.mdx
+++ b/packages/site/src/app/docs/select/page.mdx
@@ -16,7 +16,7 @@ export const metadata = {
 
 A smart dropdown component that creates, labels and sorts all its own options.
 
-## `Select` Server Component
+## `<Select>` Server Component
 
 <Example>
   <Select
@@ -33,14 +33,13 @@ A smart dropdown component that creates, labels and sorts all its own options.
 
 ## `useSelect` hook
 
-`useSelect` is a utility hook that allows for full access to Select generation data.
-Useful for generating lists or when creating custom dropdown components.
+`useSelect` is a utility hook that lets you generate options for custom dropdown components or any list type content.
 
 <Example>
   <UseSelect />
 </Example>
 
-```tsx
+```tsx {6-10}
 'use client'
 
 import { useSelect } from '@trikinco/fullstack-components/client'
@@ -75,7 +74,7 @@ export default function Page() {
 
 ## Custom Server Component with `getSelect`
 
-```tsx title="Server Component"
+```tsx {4-8} title="Server Component"
 import { getSelect } from '@trikinco/fullstack-components'
 
 export default async function Page() {

--- a/packages/site/src/app/docs/text/page.mdx
+++ b/packages/site/src/app/docs/text/page.mdx
@@ -15,7 +15,7 @@ export const metadata = {
 
 Rewrite, simplify or create text. Handles plain text, markdown and HTML.
 
-## `Text` Server Component
+## `<Text>` Server Component
 
 ### Rewriting text
 
@@ -41,7 +41,7 @@ Rewrite, simplify or create text. Handles plain text, markdown and HTML.
   by Hermitian operators. The position operator X and momentum operator P do not
   commute, but rather satisfy the canonical commutation relation.
   </p>
-  <p>Given a quantum state, the Born rule lets us compute expectation values for both X and P, and moreover for powers of them</p>
+  <p>Given a quantum state, the Born rule lets us compute expectation values for both X and P, and moreover for powers of them.</p>
 </Text>
 </Example>
 
@@ -70,7 +70,7 @@ Rewrite, simplify or create text. Handles plain text, markdown and HTML.
   <p>
     Given a quantum state, the Born rule lets us compute
     expectation values for both X and P, and moreover for powers
-    of them
+    of them.
   </p>
 </Text>
 ```
@@ -102,7 +102,7 @@ Rewrite, simplify or create text. Handles plain text, markdown and HTML.
 
 ## `useText` hook
 
-```tsx
+```tsx {6-18}
 'use client'
 
 import { useText } from '@trikinco/fullstack-components/client'
@@ -114,10 +114,11 @@ export default function Page() {
     grade: 5,
     max: 250,
     content: `
-        One consequence of the basic quantum formalism is the uncertainty principle.
-        In its most familiar form, this states that no preparation of a quantum
-        particle can imply simultaneously precise predictions both for a measurement
-        of its position and for a measurement of its momentum.
+        One consequence of the basic quantum formalism is the uncertainty 
+        principle. In its most familiar form, this states that no 
+        preparation of a quantum particle can imply simultaneously 
+        precise predictions both for a measurement of its position 
+        and for a measurement of its momentum.
         `,
   })
 
@@ -130,7 +131,7 @@ export default function Page() {
 }
 ```
 
-`useText` also accepts a tree of components in `content`. Note that only static HTML is returned.
+`useText` also accepts a tree of React components in `content`. Note that only static HTML is returned.
 
 ```tsx title="useText with HTML"
 const { isLoading, data } = useText({
@@ -150,7 +151,9 @@ const { isLoading, data } = useText({
 })
 ```
 
-```tsx title="Server Component"
+## Custom Server Component with `getText`
+
+```tsx {4-8} title="Server Component"
 import { getText } from '@trikinco/fullstack-components'
 
 export default async function Page() {

--- a/packages/site/src/components/Nav.tsx
+++ b/packages/site/src/components/Nav.tsx
@@ -1,5 +1,5 @@
 'use client'
-import type { HTMLAttributes, ReactNode } from 'react'
+import type { HTMLAttributes, ReactNode, ElementRef } from 'react'
 import Link from 'next/link'
 import { merge } from '@trikinco/fullstack-components/utils'
 import { NAME_SHORT, URL_GITHUB, URL_NPM } from '@/src/utils/constants'
@@ -7,16 +7,23 @@ import { IconGitHub } from '@/src/components/Icons/IconGitHub'
 import { IconNpm } from '@/src/components/Icons/IconNpm'
 import { ThemeSwitcher } from '@/src/modules/Theme/ThemeSwitcher'
 import { FlexSearch } from '@/src/modules/Search/FlexSearch'
+import useIsStuck from '@/src/hooks/useIsStuck'
 
 export interface NavProps extends HTMLAttributes<HTMLDivElement> {
 	children?: ReactNode
 }
 
 export const Nav = ({ children, className, ...rest }: NavProps) => {
+	const { ref, isStuck } = useIsStuck<ElementRef<'nav'>>()
+
 	return (
 		<nav
+			ref={ref}
 			className={merge(
-				'flex sticky top-0 left-0 backdrop-blur-md items-center p-6 z-20 border-b border-slate-950/5 dark:border-white/10 print:hidden',
+				'flex sticky top-[-1px] left-0 backdrop-blur-md items-center p-6 2xl:mb-8 z-20 print:hidden',
+				'transition-colors ease-in-out',
+				'border-b border-slate-950/5 dark:border-white/10 2xl:border-transparent 2xl:dark:border-transparent',
+				isStuck && '2xl:border-slate-950/5 2xl:dark:border-white/10',
 				className
 			)}
 			{...rest}
@@ -31,7 +38,10 @@ export const Nav = ({ children, className, ...rest }: NavProps) => {
 			{children}
 
 			<div className="flex gap-3 sm:gap-6 ml-auto min-h-9">
-				<FlexSearch className="hidden md:block" />
+				<FlexSearch
+					placeholder="Search documentation..."
+					className="hidden md:block"
+				/>
 				<ThemeSwitcher className="flex flex-col justify-center" />
 				<Link
 					href={URL_NPM}

--- a/packages/site/src/components/Prose.tsx
+++ b/packages/site/src/components/Prose.tsx
@@ -19,7 +19,10 @@ export function Prose<C extends ElementType = typeof defaultElement>({
 	return (
 		<Component
 			className={merge(
-				'w-full mx-auto prose dark:prose-invert prose-h1:text-3xl md:prose-h1:text-5xl prose-headings:scroll-mt-32 prose-h1:font-bold prose-h1:mb-3 focus-visible:prose-a:outline focus-visible:prose-a:outline-2 focus-visible:prose-a:outline-offset-2 focus-visible:prose-a:rounded-sm',
+				'w-full mx-auto prose dark:prose-invert',
+				'prose-h1:text-3xl md:prose-h1:text-5xl prose-h1:mb-3 md:prose-h1:mb-6 lg:prose-h1:mb-8',
+				'prose-headings:scroll-mt-32 prose-headings:text-pretty',
+				'focus-visible:prose-a:outline focus-visible:prose-a:outline-2 focus-visible:prose-a:outline-offset-2 focus-visible:prose-a:rounded-sm',
 				className
 			)}
 			{...rest}

--- a/packages/site/src/hooks/useIsStuck.ts
+++ b/packages/site/src/hooks/useIsStuck.ts
@@ -1,0 +1,42 @@
+'use client'
+import { useRef, useState, useEffect } from 'react'
+
+/**
+ * Reports when `position: sticky` elements are stuck
+ */
+export function useIsStuck<T extends HTMLElement>(
+	position: 'top' | 'right' | 'bottom' | 'left' = 'top'
+) {
+	const [isStuck, setIsStuck] = useState(false)
+	const ref = useRef<T>(null)
+
+	// Used for inline styles if needed
+	const styles = {
+		position: 'sticky',
+		[position]: -1,
+	}
+
+	useEffect(() => {
+		const cachedRef = ref.current
+		const observer = new IntersectionObserver(
+			([e]) => setIsStuck(e.intersectionRatio < 1),
+			{ threshold: [1] }
+		)
+
+		if (cachedRef) {
+			observer.observe(cachedRef)
+		}
+
+		return () => {
+			if (cachedRef) observer.unobserve(cachedRef)
+		}
+	}, [ref])
+
+	return {
+		isStuck,
+		styles,
+		ref,
+	}
+}
+
+export default useIsStuck

--- a/packages/site/src/modules/Breadcrumbs.tsx
+++ b/packages/site/src/modules/Breadcrumbs.tsx
@@ -41,10 +41,7 @@ export function Breadcrumbs({ children, className }: BreadcrumbsProps) {
 					},
 				}))}
 			/>
-			<nav
-				className={merge('lg:hidden print:hidden', className)}
-				aria-label="Breadcrumb"
-			>
+			<nav className={merge('print:hidden', className)} aria-label="Breadcrumb">
 				<ol className="flex gap-2 max-w-prose mx-auto">
 					<li className="text-sm text-slate-600 dark:text-slate-400">
 						<Link href="/">Home</Link>

--- a/packages/site/src/modules/Search/Search.tsx
+++ b/packages/site/src/modules/Search/Search.tsx
@@ -7,6 +7,10 @@ import { useSearch, type UseSearchProps } from './useSearch'
 export interface SearchProps extends UseSearchProps {
 	className?: string
 	/**
+	 * The search input placeholder
+	 */
+	placeholder?: string
+	/**
 	 * Search input on active
 	 */
 	onActive?: (active: boolean) => void
@@ -19,6 +23,7 @@ export function Search({
 	onChange,
 	onActive,
 	className,
+	placeholder,
 	value,
 	loading,
 	error,
@@ -56,6 +61,7 @@ export function Search({
 					ref={inputRef}
 					id={id}
 					value={value}
+					placeholder={placeholder}
 					isFocused={isFocused}
 					isMounted={isMounted}
 					activeResult={activeResult}

--- a/packages/site/src/modules/Search/SearchInput.tsx
+++ b/packages/site/src/modules/Search/SearchInput.tsx
@@ -59,6 +59,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 			value,
 			id,
 			className,
+			placeholder,
 			activeResult,
 			isFocused,
 			isMounted,
@@ -94,7 +95,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 						setIsFocused(false)
 					}}
 					type="search"
-					placeholder="Search documentation..."
+					placeholder={placeholder}
 					role="combobox"
 					maxLength={100}
 					aria-controls={id}

--- a/packages/site/src/styles/globals.css
+++ b/packages/site/src/styles/globals.css
@@ -71,11 +71,11 @@ pre [data-rehype-pretty-code-figure] {
 }
 
 [data-highlighted-chars] {
-	@apply rounded-md bg-slate-800/10 dark:bg-slate-800;
+	@apply rounded-md bg-slate-400/10 dark:bg-slate-800;
 }
 
 [data-highlighted-line] {
-	@apply rounded-md bg-slate-800/10 dark:bg-slate-800;
+	@apply bg-slate-400/10 dark:bg-slate-800;
 }
 
 .bg-pattern {
@@ -126,6 +126,14 @@ pre [data-rehype-pretty-code-figure] {
 
 .toc-active {
 	@apply font-bold text-blue-600 dark:text-blue-400;
+}
+
+.prose h1 > .heading-link {
+	@apply font-bold;
+}
+
+.prose h1 + p {
+	@apply text-lg text-pretty;
 }
 
 .heading-link {


### PR DESCRIPTION
![Screenshot 2024-01-09 at 17 18 48](https://github.com/trikinco/fullstack-components/assets/7847281/3f731dcd-12a7-4ff1-8194-c9add47e4797)
![Screenshot 2024-01-09 at 17 19 13](https://github.com/trikinco/fullstack-components/assets/7847281/f37aef28-d313-40ba-9ccf-2fe5835fcadf)
![Screenshot 2024-01-09 at 17 19 24](https://github.com/trikinco/fullstack-components/assets/7847281/0d767096-b738-40f5-ae3f-a2f987b09d91)
![Screenshot 2024-01-09 at 17 20 33](https://github.com/trikinco/fullstack-components/assets/7847281/6ceb5cdf-d722-4485-a916-b8abdd736643)

The new Prompt JSON mode demo
![Screenshot 2024-01-09 at 17 21 17](https://github.com/trikinco/fullstack-components/assets/7847281/9d616046-db74-44fa-ad87-e55da9414472)
