### PR TITLE
chore: Configures eslint correctly for `/client` and `/utils`, and enforce explicit `type` imports

### DIFF
--- a/packages/fullstack-components/.eslintrc.cjs
+++ b/packages/fullstack-components/.eslintrc.cjs
@@ -3,7 +3,7 @@ module.exports = {
 	parserOptions: {
 		project: './tsconfig.json',
 		sourceType: 'module',
-		ecmaVersion: 'es2019',
+		ecmaVersion: 'ES2022',
 	},
 	plugins: [
 		'@typescript-eslint/eslint-plugin',
@@ -31,12 +31,19 @@ module.exports = {
 		node: true,
 		jest: true,
 	},
-	ignorePatterns: ['.eslintrc.cjs', 'dist'],
+	ignorePatterns: ['.eslintrc.cjs', 'dist', 'client.d.ts', 'utils.d.ts'],
 	rules: {
 		'@typescript-eslint/interface-name-prefix': 'off',
 		'@typescript-eslint/explicit-function-return-type': 'off',
 		'@typescript-eslint/explicit-module-boundary-types': 'off',
 		'@typescript-eslint/no-explicit-any': 'off',
+		'@typescript-eslint/consistent-type-imports': [
+			'error',
+			{
+				prefer: 'type-imports',
+				fixStyle: 'inline-type-imports',
+			},
+		],
 		'jest/expect-expect': [
 			'error',
 			{

--- a/packages/fullstack-components/package.json
+++ b/packages/fullstack-components/package.json
@@ -59,9 +59,7 @@
 		"package.json",
 		"README.md",
 		"client.js",
-		"client.d.ts",
-		"utils.js",
-		"utils.d.ts"
+		"utils.js"
 	],
 	"engines": {
 		"node": ">=18"

--- a/packages/fullstack-components/src/audioService.ts
+++ b/packages/fullstack-components/src/audioService.ts
@@ -52,22 +52,19 @@ export interface AudioFileResponse extends AudioResponseBase {
 	contentType: string
 }
 
-type AudioServiceOptions = {
+export type AudioServiceOptions = (
+	| AudioSpeechModeRequestBody
+	| AudioTranscriptionModeRequestBody
+	| AudioTranslationModeRequestBody
+) & {
 	/**
 	 * @default `process.env.OPENAI_API_KEY`.
 	 */
 	openAIApiKey: string
 }
 
-export type AudioOptions = (
-	| AudioSpeechModeRequestBody
-	| AudioTranscriptionModeRequestBody
-	| AudioTranslationModeRequestBody
-) &
-	AudioServiceOptions
-
 export async function runAudioService(
-	options: AudioOptions
+	options: AudioServiceOptions
 ): Promise<AudioTextResponse | AudioFileResponse> {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const { openAIApiKey, ...request } = options
@@ -131,7 +128,7 @@ export async function runAudioService(
 	}
 }
 
-async function getAudioRequest(options: AudioOptions) {
+async function getAudioRequest(options: AudioServiceOptions) {
 	const openai = new OpenAI({
 		apiKey: options.openAIApiKey,
 	})

--- a/packages/fullstack-components/src/components/Track.tsx
+++ b/packages/fullstack-components/src/components/Track.tsx
@@ -1,8 +1,8 @@
 import type OpenAI from 'openai'
 import type { FileLike } from 'openai/uploads'
 import type { DetailedHTMLProps, TrackHTMLAttributes } from 'react'
+import type { ReadStream } from 'fs'
 import { transformVTT, type Cue } from '../handlers/audio/audioVttParser'
-import fs from 'fs'
 import { getAudio } from '../handlers/audio/audioClient'
 import { getApiFile } from '../utils/getApiFile'
 import { toBase64Url } from '../utils/toBase64Url'
@@ -117,7 +117,7 @@ export async function caption(
 		prompt,
 		name,
 	} = options || {}
-	let content: fs.ReadStream | FileLike | undefined
+	let content: ReadStream | FileLike | undefined
 
 	try {
 		content = getApiFile(src, type, name)

--- a/packages/fullstack-components/src/components/Transcript.tsx
+++ b/packages/fullstack-components/src/components/Transcript.tsx
@@ -2,7 +2,7 @@ import type OpenAI from 'openai'
 import type { FileLike } from 'openai/uploads'
 import type { ElementType, HTMLAttributes } from 'react'
 import type { AsComponent } from '../types'
-import fs from 'fs'
+import type { ReadStream } from 'fs'
 import { getAudio } from '../handlers/audio/audioClient'
 import { getApiFile } from '../utils/getApiFile'
 
@@ -78,7 +78,7 @@ export async function transcribe(
 		prompt,
 		name,
 	} = options || {}
-	let content: fs.ReadStream | FileLike | undefined
+	let content: ReadStream | FileLike | undefined
 
 	try {
 		content = getApiFile(src, type, name)

--- a/packages/fullstack-components/src/enums/ApiUrlEnum.ts
+++ b/packages/fullstack-components/src/enums/ApiUrlEnum.ts
@@ -1,3 +1,6 @@
+/**
+ * All the API URLs used by fetchers, hooks and client components.
+ */
 export const ApiUrlEnum = {
 	prompt: '/api/fsutils/prompt',
 	errorEnhancer: '/api/fsutils/errorEnhancer',

--- a/packages/fullstack-components/src/handlers/audio/audioHandler.ts
+++ b/packages/fullstack-components/src/handlers/audio/audioHandler.ts
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/naming-convention */
-import { NextApiResponse, NextApiRequest } from 'next'
-import { NextRequest, NextResponse } from 'next/server'
+import type { NextApiResponse, NextApiRequest } from 'next'
+import { type NextRequest, NextResponse } from 'next/server'
 import {
 	// eslint-disable-next-line unicorn/prevent-abbreviations
-	AppRouteHandlerContext,
-	FullstackComponentsHandler,
-	Handler,
+	type AppRouteHandlerContext,
+	type FullstackComponentsHandler,
+	type Handler,
 	assertReqRes,
 	getHandler,
 } from '../../nextjs-handlers'
-import { AudioClient } from './audioClient'
+import type { AudioClient } from './audioClient'
 import { type AudioRequestBody, type AudioOptions, AudioError } from './models'
 
 /**

--- a/packages/fullstack-components/src/handlers/block/blockHandler.ts
+++ b/packages/fullstack-components/src/handlers/block/blockHandler.ts
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/naming-convention */
-import { NextApiResponse, NextApiRequest } from 'next'
-import { NextRequest, NextResponse } from 'next/server'
+import type { NextApiResponse, NextApiRequest } from 'next'
+import { type NextRequest, NextResponse } from 'next/server'
 import {
 	// eslint-disable-next-line unicorn/prevent-abbreviations
-	AppRouteHandlerContext,
-	FullstackComponentsHandler,
-	Handler,
+	type AppRouteHandlerContext,
+	type FullstackComponentsHandler,
+	type Handler,
 	assertReqRes,
 	getHandler,
 } from '../../nextjs-handlers'
-import { BlockClient } from './blockClient'
+import type { BlockClient } from './blockClient'
 import { type BlockRequestBody, type BlockOptions, BlockError } from './models'
 
 /**

--- a/packages/fullstack-components/src/handlers/errorEnhancer/errorParser.ts
+++ b/packages/fullstack-components/src/handlers/errorEnhancer/errorParser.ts
@@ -1,19 +1,19 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { NextApiResponse, NextApiRequest } from 'next'
-import { NextRequest, NextResponse } from 'next/server'
+import type { NextApiResponse, NextApiRequest } from 'next'
+import { type NextRequest, NextResponse } from 'next/server'
 import {
 	// eslint-disable-next-line unicorn/prevent-abbreviations
-	AppRouteHandlerContext,
-	FullstackComponentsHandler,
-	Handler,
+	type AppRouteHandlerContext,
+	type FullstackComponentsHandler,
+	type Handler,
 	assertReqRes,
 	getHandler,
 } from '../../nextjs-handlers'
-import { ErrorClient } from './errorClient'
+import type { ErrorClient } from './errorClient'
 import {
-	ErrorParserOptions,
 	ErrorEnhancementError,
-	ErrorEnhancementRequestBody,
+	type ErrorParserOptions,
+	type ErrorEnhancementRequestBody,
 } from './models'
 
 /**

--- a/packages/fullstack-components/src/handlers/htmlPage/htmlPageHandler.ts
+++ b/packages/fullstack-components/src/handlers/htmlPage/htmlPageHandler.ts
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/naming-convention */
-import { NextApiResponse, NextApiRequest } from 'next'
-import { NextRequest, NextResponse } from 'next/server'
+import type { NextApiResponse, NextApiRequest } from 'next'
+import { type NextRequest, NextResponse } from 'next/server'
 import {
 	// eslint-disable-next-line unicorn/prevent-abbreviations
-	AppRouteHandlerContext,
-	FullstackComponentsHandler,
-	Handler,
+	type AppRouteHandlerContext,
+	type FullstackComponentsHandler,
+	type Handler,
 	assertReqRes,
 	getHandler,
 } from '../../nextjs-handlers'
-import { HtmlPageClient } from './htmlPageClient'
+import type { HtmlPageClient } from './htmlPageClient'
 import {
 	type HtmlPageRequestBody,
 	type HtmlPageOptions,

--- a/packages/fullstack-components/src/handlers/image/imageHandler.ts
+++ b/packages/fullstack-components/src/handlers/image/imageHandler.ts
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/naming-convention */
-import { NextApiResponse, NextApiRequest } from 'next'
-import { NextRequest, NextResponse } from 'next/server'
+import type { NextApiResponse, NextApiRequest } from 'next'
+import { type NextRequest, NextResponse } from 'next/server'
 import {
 	// eslint-disable-next-line unicorn/prevent-abbreviations
-	AppRouteHandlerContext,
-	FullstackComponentsHandler,
-	Handler,
+	type AppRouteHandlerContext,
+	type FullstackComponentsHandler,
+	type Handler,
 	assertReqRes,
 	getHandler,
 } from '../../nextjs-handlers'
-import { ImageClient } from './imageClient'
+import type { ImageClient } from './imageClient'
 import { type ImageRequestBody, type ImageOptions, ImageError } from './models'
 
 /**

--- a/packages/fullstack-components/src/handlers/image/models.ts
+++ b/packages/fullstack-components/src/handlers/image/models.ts
@@ -1,4 +1,4 @@
-import OpenAI from 'openai'
+import type OpenAI from 'openai'
 
 export type ImageGenerationOptions = Partial<OpenAI.ImageGenerateParams>
 

--- a/packages/fullstack-components/src/handlers/notFoundEnhancer/notFoundEnhancer.ts
+++ b/packages/fullstack-components/src/handlers/notFoundEnhancer/notFoundEnhancer.ts
@@ -1,23 +1,23 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/naming-convention */
-import { NextApiResponse, NextApiRequest } from 'next'
-import { NextRequest, NextResponse } from 'next/server'
+import type { NextApiResponse, NextApiRequest } from 'next'
+import { type NextRequest, NextResponse } from 'next/server'
 import {
 	// eslint-disable-next-line unicorn/prevent-abbreviations
-	AppRouteHandlerContext,
-	FullstackComponentsHandler,
-	Handler,
+	type AppRouteHandlerContext,
+	type FullstackComponentsHandler,
+	type Handler,
 	assertReqRes,
 	getHandler,
 } from '../../nextjs-handlers'
-import { NotFoundEnhancerSitemapSelector } from './notFoundEnhancerSitemapSelector'
-import { NotFoundEnhancerContentGenerator } from './notFoundEnhancerContentGenerator'
-import { ChatGptCompletionResponse } from '../../chatGptService'
+import type { NotFoundEnhancerSitemapSelector } from './notFoundEnhancerSitemapSelector'
+import type { NotFoundEnhancerContentGenerator } from './notFoundEnhancerContentGenerator'
+import type { ChatGptCompletionResponse } from '../../chatGptService'
 import {
 	NotFoundEnhancerError,
-	NotFoundEnhancerOptions,
-	NotFoundEnhancerRequestBody,
-	NotFoundEnhancerResponse,
+	type NotFoundEnhancerOptions,
+	type NotFoundEnhancerRequestBody,
+	type NotFoundEnhancerResponse,
 } from './models'
 
 /**

--- a/packages/fullstack-components/src/handlers/notFoundEnhancer/sitemapParser.ts
+++ b/packages/fullstack-components/src/handlers/notFoundEnhancer/sitemapParser.ts
@@ -1,4 +1,5 @@
 import sitemapper from 'sitemapper'
+
 let sitemapCache: string = ''
 
 export async function sitemapFromCache(currentHost: string) {

--- a/packages/fullstack-components/src/handlers/prompt/promptHandler.ts
+++ b/packages/fullstack-components/src/handlers/prompt/promptHandler.ts
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/naming-convention */
-import { NextApiResponse, NextApiRequest } from 'next'
-import { NextRequest, NextResponse } from 'next/server'
+import type { NextApiResponse, NextApiRequest } from 'next'
+import { type NextRequest, NextResponse } from 'next/server'
 import {
 	// eslint-disable-next-line unicorn/prevent-abbreviations
-	AppRouteHandlerContext,
-	FullstackComponentsHandler,
-	Handler,
+	type AppRouteHandlerContext,
+	type FullstackComponentsHandler,
+	type Handler,
 	assertReqRes,
 	getHandler,
 } from '../../nextjs-handlers'
-import { PromptClient } from './promptClient'
+import type { PromptClient } from './promptClient'
 import {
 	type PromptRequestBody,
 	type PromptOptions,

--- a/packages/fullstack-components/src/handlers/select/selectHandler.ts
+++ b/packages/fullstack-components/src/handlers/select/selectHandler.ts
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/naming-convention */
-import { NextApiResponse, NextApiRequest } from 'next'
-import { NextRequest, NextResponse } from 'next/server'
+import type { NextApiResponse, NextApiRequest } from 'next'
+import { type NextRequest, NextResponse } from 'next/server'
 import {
 	// eslint-disable-next-line unicorn/prevent-abbreviations
-	AppRouteHandlerContext,
-	FullstackComponentsHandler,
-	Handler,
+	type AppRouteHandlerContext,
+	type FullstackComponentsHandler,
+	type Handler,
 	assertReqRes,
 	getHandler,
 } from '../../nextjs-handlers'
-import { SelectClient } from './selectClient'
+import type { SelectClient } from './selectClient'
 import {
 	type SelectRequestBody,
 	type SelectOptions,

--- a/packages/fullstack-components/src/handlers/text/textHandler.ts
+++ b/packages/fullstack-components/src/handlers/text/textHandler.ts
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/naming-convention */
-import { NextApiResponse, NextApiRequest } from 'next'
-import { NextRequest, NextResponse } from 'next/server'
+import type { NextApiResponse, NextApiRequest } from 'next'
+import { type NextRequest, NextResponse } from 'next/server'
 import {
 	// eslint-disable-next-line unicorn/prevent-abbreviations
-	AppRouteHandlerContext,
-	FullstackComponentsHandler,
-	Handler,
+	type AppRouteHandlerContext,
+	type FullstackComponentsHandler,
+	type Handler,
 	assertReqRes,
 	getHandler,
 } from '../../nextjs-handlers'
-import { TextClient } from './textClient'
+import type { TextClient } from './textClient'
 import { type TextRequestBody, type TextOptions, TextError } from './models'
 
 /**

--- a/packages/fullstack-components/src/index.ts
+++ b/packages/fullstack-components/src/index.ts
@@ -1,10 +1,10 @@
 /* eslint-disable unicorn/prevent-abbreviations */
 import handlerFactory from './next-routing'
-import { _init } from './init'
+import { _init, type FullstackComponentsServer } from './init'
 
+// Handlers for each feature
 import type { HandleErrorParser } from './handlers/errorEnhancer/errorParser'
 import type { HandleNotFoundEnhancement } from './handlers/notFoundEnhancer/notFoundEnhancer'
-import type { FullstackComponentsServer } from './init'
 import type { HandlePrompt } from './handlers/prompt/promptHandler'
 import type { HandleBlock } from './handlers/block/blockHandler'
 import type { HandleImage } from './handlers/image/imageHandler'
@@ -113,7 +113,7 @@ const handleFSComponents = handlerFactory({
 
 // Server components
 export { Audio } from './components/Audio'
-export { Track, Cue } from './components/Track'
+export { Track, type Cue } from './components/Track'
 export { Transcript } from './components/Transcript'
 export { Prompt } from './components/Prompt'
 export { Image } from './components/Image/Image'
@@ -143,9 +143,9 @@ export {
 export { BlockClient, getBlock } from './handlers/block/blockClient'
 
 // Public library types
-export { ChatGptCompletionResponse } from './chatGptService'
-export { ImageGenerationResponse } from './imageGenerationService'
-export { AudioTextResponse as AudioResponse } from './audioService'
+export type { ChatGptCompletionResponse } from './chatGptService'
+export type { ImageGenerationResponse } from './imageGenerationService'
+export type { AudioTextResponse, AudioFileResponse } from './audioService'
 export * from './handlers/audio/models'
 export * from './handlers/errorEnhancer/models'
 export * from './handlers/notFoundEnhancer/models'
@@ -155,7 +155,7 @@ export * from './handlers/image/models'
 export * from './handlers/select/models'
 export * from './handlers/text/models'
 export * from './handlers/htmlPage/models'
-export { AppRouteHandlerContext } from './nextjs-handlers'
+export type { AppRouteHandlerContext } from './nextjs-handlers'
 
 export {
 	getInstance,
@@ -171,5 +171,5 @@ export {
 	handleFSComponents,
 }
 
-export { FullstackComponentsServer } from './init'
+export type { FullstackComponentsServer } from './init'
 export * from './types'

--- a/packages/fullstack-components/src/index.ts
+++ b/packages/fullstack-components/src/index.ts
@@ -99,6 +99,14 @@ const handleNotFoundEnhancement: HandleNotFoundEnhancement = ((
 ) =>
 	getInstance().handleNotFoundEnhancement(...args)) as HandleNotFoundEnhancement
 
+/**
+ * The API handler factory for all library features.
+ * @example Usage in `app/api/fsutils/[...fscomponents]/route.ts`
+ * ```ts
+ * const fscHandler = handleFSComponents(fscOptions)
+ * export { fscHandler as GET, fscHandler as POST }
+ * ```
+ */
 const handleFSComponents = handlerFactory({
 	handleAudio: handleAudioRequest,
 	handleText: handleTextRequest,

--- a/packages/fullstack-components/src/init.ts
+++ b/packages/fullstack-components/src/init.ts
@@ -1,26 +1,30 @@
 import { ErrorClient } from './handlers/errorEnhancer/errorClient'
 import errorParserHandler, {
-	HandleErrorParser,
+	type HandleErrorParser,
 } from './handlers/errorEnhancer/errorParser'
 import notFoundEnhancementHandler, {
-	HandleNotFoundEnhancement,
+	type HandleNotFoundEnhancement,
 } from './handlers/notFoundEnhancer/notFoundEnhancer'
 import { NotFoundEnhancerContentGenerator } from './handlers/notFoundEnhancer/notFoundEnhancerContentGenerator'
 import { NotFoundEnhancerSitemapSelector } from './handlers/notFoundEnhancer/notFoundEnhancerSitemapSelector'
 import { PromptClient } from './handlers/prompt/promptClient'
-import promptHandler, { HandlePrompt } from './handlers/prompt/promptHandler'
+import promptHandler, {
+	type HandlePrompt,
+} from './handlers/prompt/promptHandler'
 import { BlockClient } from './handlers/block/blockClient'
-import blockHandler, { HandleBlock } from './handlers/block/blockHandler'
-import imageHandler, { HandleImage } from './handlers/image/imageHandler'
+import blockHandler, { type HandleBlock } from './handlers/block/blockHandler'
+import imageHandler, { type HandleImage } from './handlers/image/imageHandler'
 import { ImageClient } from './handlers/image/imageClient'
-import selectHandler, { HandleSelect } from './handlers/select/selectHandler'
+import selectHandler, {
+	type HandleSelect,
+} from './handlers/select/selectHandler'
 import { SelectClient } from './handlers/select/selectClient'
-import textHandler, { HandleText } from './handlers/text/textHandler'
+import textHandler, { type HandleText } from './handlers/text/textHandler'
 import { TextClient } from './handlers/text/textClient'
-import audioHandler, { HandleAudio } from './handlers/audio/audioHandler'
+import audioHandler, { type HandleAudio } from './handlers/audio/audioHandler'
 import { AudioClient } from './handlers/audio/audioClient'
 import htmlPageHandler, {
-	HandleHtmlPage,
+	type HandleHtmlPage,
 } from './handlers/htmlPage/htmlPageHandler'
 import { HtmlPageClient } from './handlers/htmlPage/htmlPageClient'
 

--- a/packages/fullstack-components/src/nextjs-handlers.ts
+++ b/packages/fullstack-components/src/nextjs-handlers.ts
@@ -2,8 +2,8 @@
 /* eslint-disable @typescript-eslint/no-redundant-type-constituents */
 // This is all borrowed from auth0 nextjs
 
-import { NextApiRequest, NextApiResponse } from 'next'
-import { NextRequest } from 'next/server'
+import type { NextApiRequest, NextApiResponse } from 'next'
+import type { NextRequest } from 'next/server'
 import type { IncomingMessage } from 'http'
 
 export type AppRouteHandlerContext = {

--- a/packages/fullstack-components/src/reqHelper.ts
+++ b/packages/fullstack-components/src/reqHelper.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage } from 'http'
-import { NextApiRequest } from 'next'
-import { NextRequest } from 'next/server'
+import type { NextApiRequest } from 'next'
+import type { NextRequest } from 'next/server'
 
 type Req =
 	| IncomingMessage

--- a/packages/fullstack-components/src/types/ChatMessage.ts
+++ b/packages/fullstack-components/src/types/ChatMessage.ts
@@ -1,3 +1,3 @@
-import OpenAI from 'openai'
+import type OpenAI from 'openai'
 
 export type ChatMessage = OpenAI.ChatCompletionMessageParam

--- a/packages/fullstack-components/src/types/Image.ts
+++ b/packages/fullstack-components/src/types/Image.ts
@@ -1,5 +1,5 @@
-import OpenAI from 'openai'
-import { type ImageProps as NextImageProps } from 'next/image'
+import type OpenAI from 'openai'
+import type { ImageProps as NextImageProps } from 'next/image'
 import type { SyntheticEvent } from 'react'
 import type { ImageResponse } from '../handlers/image/models'
 

--- a/packages/fullstack-components/src/types/handlers.ts
+++ b/packages/fullstack-components/src/types/handlers.ts
@@ -28,10 +28,6 @@ export type FactoryHandlers = {
 	handleNotFoundEnhancement: HandleNotFoundEnhancement
 }
 
-// taken from auth0 nextjs
-// to use - create a route in /api/fscomponents/[futc].ts
-export type FSCOptions = ApiHandlers | ErrorHandlers
-
 /**
  * @ignore
  */
@@ -47,6 +43,12 @@ export type ApiHandlers = {
 export type ErrorHandlers = {
 	onError?: PageRouterOnError | AppRouterOnError
 }
+
+/**
+ * API route handlers and options for `handleFSComponents`,
+ * responsible for configuring and creating routes at `/api/fsutils/[...fscomponents]`
+ */
+export type FSCOptions = ApiHandlers | ErrorHandlers
 
 export type FSCApiHandler = (
 	userHandlers?: FSCOptions

--- a/packages/fullstack-components/src/types/handlers.ts
+++ b/packages/fullstack-components/src/types/handlers.ts
@@ -1,4 +1,4 @@
-import { ApiUrlEnum } from '../enums/ApiUrlEnum'
+import type { ApiUrlEnum } from '../enums/ApiUrlEnum'
 import type { NextApiHandler } from 'next'
 import type {
 	AppRouteHandler,

--- a/packages/fullstack-components/tsconfig.build.json
+++ b/packages/fullstack-components/tsconfig.build.json
@@ -7,6 +7,8 @@
 		"dist",
 		"client.js",
 		"client.d.ts",
+		"utils.js",
+		"utils.d.ts",
 		"**/*spec.ts"
 	]
 }

--- a/packages/fullstack-components/tsconfig.json
+++ b/packages/fullstack-components/tsconfig.json
@@ -15,7 +15,6 @@
 		"noImplicitReturns": true,
 		"noFallthroughCasesInSwitch": true,
 		"moduleResolution": "node",
-		//"skipLibCheck": true,
 		"skipDefaultLibCheck": true,
 		"resolveJsonModule": true,
 		"esModuleInterop": true,
@@ -24,6 +23,8 @@
 		"target": "ES2022",
 		"lib": ["es2022", "DOM"],
 		"sourceMap": true,
-		"outDir": "./dist"
-	}
+		"outDir": "dist"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "client.d.ts", "utils.d.ts"]
 }


### PR DESCRIPTION
- exclude and ignore correct files to resolve TS `Cannot write file because it would overwrite input file` errors
- sets correct ecmaVersion in `.eslintrc` to ES2022 to stay in sync with other files
- enforces `type` imports for clarity, perf, and improved logging - especially for circularity 